### PR TITLE
fix(parser/html): remove rel attr from inlined styles

### DIFF
--- a/lib/parser/html.js
+++ b/lib/parser/html.js
@@ -47,7 +47,8 @@ function appendFileSource(file, src) {
 }
 function createImportTag(tag, src, attrs) {
   const nodeName = tag === 'link' ? 'style' : 'script';
-  return `<${nodeName} ${attrs}>@${src}</${nodeName}>`;
+  if (tag === 'link') delete attrs.rel;
+  return `<${nodeName} ${flattenAttrs(attrs)}>@${src}</${nodeName}>`;
 }
 
 /**
@@ -62,7 +63,7 @@ function createAMDImportTag(tag, src, attrs) {
   attrs.src = `__amd_${attrs['data-main']}`;
   if (!path.extname(attrs.src)) attrs.src += '.js';
   delete attrs['data-main'];
-  return `<script ${attrs}></script>`;
+  return `<script ${flattenAttrs(attrs)}></script>`;
 }
 
 function getNameForInlineResource(tag, filename, fileType, line, column) {
@@ -75,7 +76,7 @@ function registerTagContentsAsFile(name, content, line, column) {
   tmpFiles[`${name}_meta`] = { line, column };
 }
 function createInlineTag(tag, src, attrs) {
-  return `<${tag} ${attrs}>@${src}</${tag}>`;
+  return `<${tag} ${flattenAttrs(attrs)}>@${src}</${tag}>`;
 }
 
 function parse(match, tag, attrs, textContent, index, content) {
@@ -107,8 +108,6 @@ function parse(match, tag, attrs, textContent, index, content) {
     removeInlineAttrs(attrs);
     appendFileSource(file, src);
   }
-
-  attrs = flattenAttrs(attrs);
 
   if (tag.match(/style|script/) && textContent) {
     const line   = getTextIndexLineNumber(content, index),

--- a/test/unit/parser-html.js
+++ b/test/unit/parser-html.js
@@ -1,0 +1,10 @@
+const {test}  = require('ava'),
+      html    = require('../../lib/parser/html');
+
+test('should strip rel atrr from expanded style tags', (t) => {
+  const content = html.setContent({
+    name: 'index.html',
+    contents: '<link data-inline rel=stylesheet href=index.less>'
+  });
+  t.false(/rel="stylesheet"/.test(content));
+});


### PR DESCRIPTION
```html
<link data-inline rel=stylesheet href=index.less>
```
is currently expanding to

```html
<style rel=stylesheet>…</style>
```
> Attribute `rel` not allowed on element `style` at this point