### PR TITLE
refactor: add project linting using xo code-style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,11 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.js]
+indent_style = tab
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pakku | パック
 [![Travis CI](https://img.shields.io/travis/zanona/pakku/master.svg?style=flat-square)](https://travis-ci.org/zanona/pakku)
 [![AppVeyor](https://img.shields.io/appveyor/ci/zanona/pakku/master.svg?label=build+(win32)&style=flat-square)](https://ci.appveyor.com/project/zanona/pakku/branch/master)
 [![NPM Version](https://img.shields.io/npm/v/pakku.svg?style=flat-square)](https://npmjs.com/package/pakku)
-[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square)](https://standardjs.com)
+[![JavaScript Style Guide](https://img.shields.io/badge/code_style-XO-brightgreen.svg?style=flat-square)](https://github.com/sindresorhus/xo)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square)](https://conventionalcommits.org)
 
 

--- a/bin/pakku.js
+++ b/bin/pakku.js
@@ -4,33 +4,40 @@ const log = require('../lib/utils/log')
 const pkg = require('../package')
 const run = require('../lib')
 
-function parseOptions (args) {
-  return args.reduce((opts, opt) => {
-    if (!opt.match(/^-+/)) return opts.args.push(opt) && opts
-    const kv = opt.split('=')
-    const k = kv[0].replace(/-+/, '').trim()
-    const v = kv[1] ? kv[1].trim() : true
-    opts[k] = v
-    return opts
-  }, {args: []})
+function parseOptions(args) {
+	return args.reduce((opts, opt) => {
+		if (!opt.match(/^-+/)) {
+			return opts.args.push(opt) && opts
+		}
+		const kv = opt.split('=')
+		const k = kv[0].replace(/-+/, '').trim()
+		const v = kv[1] ? kv[1].trim() : true
+		opts[k] = v
+		return opts
+	}, {args: []})
 }
-function version () {
-  log.info(
+function version() {
+	log.info(
     '%s - %s \nVersion: %s',
-    pkg.name.replace(/^\w/, (m) => m.toUpperCase()),
+    pkg.name.replace(/^\w/, m => m.toUpperCase()),
     pkg.description,
     pkg.version
   )
 }
-function help () {
-  version()
-  log.info(
+function help() {
+	version()
+	log.info(
     'Usage:',
     'pakku <path-to-index-page.html> <build-directory>'
   )
 }
 
-if (options.v) version()
-if (options.h || !options.args.length) help()
+if (options.v) {
+	version()
+}
+if (options.h || options.args.length === 0) {
+	help()
+}
 
 run(options.args[0], options.args[1], options)
+		.on('fatal', () => process.exit(1))

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -5,36 +5,40 @@ const path = require('path')
 const filendir = require('filendir')
 const log = require('../utils').log
 
-function run (file) {
-  const dir = this.toString()
-  const p = path.resolve(dir, file.vname)
-  return new Promise((resolve, reject) => {
-    return filendir.writeFile(p, file.contents, (err) => {
-      if (err) {
-        err.fileName = file.name
-        reject(err)
-      }
-      log.info(`SAVING: ${file.name} → ${path.join(dir, file.vname)}`)
-      resolve(file)
-    })
-  })
+function run(file) {
+	const dir = this.toString()
+	const p = path.resolve(dir, file.vname)
+	return new Promise((resolve, reject) => {
+		return filendir.writeFile(p, file.contents, err => {
+			if (err) {
+				err.fileName = file.name
+				reject(err)
+			}
+			log.info(`SAVING: ${file.name} → ${path.join(dir, file.vname)}`)
+			resolve(file)
+		})
+	})
 }
 
-function createBuildDir (dir) {
-  return new Promise((resolve, reject) => {
-    const cmd = platform === 'win32' ? 'rmdir /s /q 2>nul' : 'rm -rf'
-    exec(`${cmd} ${dir}`, () => {
-      mkdir(dir, (mkErr) => {
-        if (mkErr) return reject(mkErr)
-        resolve()
-      })
-    })
-  })
+function createBuildDir(dir) {
+	return new Promise((resolve, reject) => {
+		const cmd = platform === 'win32' ? 'rmdir /s /q 2>nul' : 'rm -rf'
+		exec(`${cmd} ${dir}`, () => {
+			mkdir(dir, mkErr => {
+				if (mkErr) {
+					return reject(mkErr)
+				}
+				resolve()
+			})
+		})
+	})
 }
 
 module.exports = function (targetDir, files) {
-  if (!targetDir) throw new Error('No Build dir specified')
-  return createBuildDir(targetDir).then(() => {
-    return Promise.all(files.map(run, targetDir))
-  })
+	if (!targetDir) {
+		throw new Error('No Build dir specified')
+	}
+	return createBuildDir(targetDir).then(() => {
+		return Promise.all(files.map(run, targetDir))
+	})
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,89 +11,101 @@ const parser = require('./parser')()
 const sourcemaps = require('./sourcemaps')
 const build = require('./build')
 
-function checkOption (options, opt) {
-  opt = options[opt]
-  if (!opt) return
-  return opt
+function checkOption(options, opt) {
+	opt = options[opt]
+	if (!opt) {
+		return
+	}
+	return opt
 }
-function getFilesArray (cachedFiles) {
-  const files = Object.keys(cachedFiles).map((k) => cachedFiles[k])
-  return Promise.resolve(files)
+function getFilesArray(cachedFiles) {
+	const files = Object.keys(cachedFiles).map(k => cachedFiles[k])
+	return Promise.resolve(files)
 }
-function getFilesByType (files, type) {
-  return Promise.resolve(files.filter((f) => f.type === type))
+function getFilesByType(files, type) {
+	return Promise.resolve(files.filter(f => f.type === type))
 }
-function renameFiles (files) {
-  log.info('RENAMING FILES')
-  return vname(files).then(() => files)
+function renameFiles(files) {
+	log.info('RENAMING FILES')
+	return vname(files).then(() => files)
 }
-function rewriteLinksInFiles (allFiles, files) {
-  if (!files.length) return files
-  const type = files[0].type.toUpperCase()
-  log.info(`REWRITING LINKS IN ${type} FILES`)
-  return linkRewriter(files, allFiles).then(() => files)
+function rewriteLinksInFiles(allFiles, files) {
+	if (files.length === 0) {
+		return files
+	}
+	const type = files[0].type.toUpperCase()
+	log.info(`REWRITING LINKS IN ${type} FILES`)
+	return linkRewriter(files, allFiles).then(() => files)
 }
-function processFiles (type, message, files) {
-  log.info(message)
-  return getFilesByType(files, type)
+function processFiles(type, message, files) {
+	log.info(message)
+	return getFilesByType(files, type)
     .then(rewriteLinksInFiles.bind(this, files))
     .then(min[type])
     .then(() => files)
 }
-function processSourceMaps (files) {
-  if (!checkOption('sourcemaps')) return Promise.resolve(files)
-  log.info('GENERATING SOURCE MAPS…')
-  return sourcemaps(files).then((maps) => {
-    maps.forEach((m) => files.push(m))
-    return maps
-  }).then(() => files)
+function processSourceMaps(files) {
+	if (!checkOption('sourcemaps')) {
+		return Promise.resolve(files)
+	}
+	log.info('GENERATING SOURCE MAPS…')
+	return sourcemaps(files).then(maps => {
+		maps.forEach(m => files.push(m))
+		return maps
+	}).then(() => files)
 }
-function processImages (files) {
-  if (checkOption('no-compress-images')) return Promise.resolve(files)
-  log.info('REVEALING YOUR PICTURES…')
-  return getFilesByType(files, 'img')
+function processImages(files) {
+	if (checkOption('no-compress-images')) {
+		return Promise.resolve(files)
+	}
+	log.info('REVEALING YOUR PICTURES…')
+	return getFilesByType(files, 'img')
     .then(min.img)
     .then(() => files)
 }
-function buildFiles (buildDir, files) {
-  log.info('STORING YOUR GOODIES…')
-  const validFiles = files.filter((f) => !f.inline && !f.skip)
-  return build(buildDir, validFiles).then(() => files)
+function buildFiles(buildDir, files) {
+	log.info('STORING YOUR GOODIES…')
+	const validFiles = files.filter(f => !f.inline && !f.skip)
+	return build(buildDir, validFiles).then(() => files)
 }
 
-function checkQueue (file) {
-  return queue.filter((item) => item.name === file.name).length
+function checkQueue(file) {
+	return queue.filter(item => item.name === file.name).length
 }
-function onError (e) {
-  log.error(e)
-  parser.emit('fatal', e)
-  process.exit(1)
+function onError(e) {
+	log.error(e)
+	parser.emit('fatal', e)
+	throw e
 }
-function onResourceFound (file) {
-  if (cache[file.name]) return
-  if (file.done) {
-    cache[file.name] = file
-    log.success(`CACHED ${file.name}`)
-  } else if (!checkQueue(file)) {
-    queue.push(file)
-  }
+function onResourceFound(file) {
+	if (cache[file.name]) {
+		return
+	}
+	if (file.done) {
+		cache[file.name] = file
+		log.success(`CACHED ${file.name}`)
+	} else if (!checkQueue(file)) {
+		queue.push(file)
+	}
 }
-function onFileComplete () {
-  if (queue.length) {
-    const next = queue.shift()
-    parser.parse(next)
-  } else {
-    parser.emit('end')
-  }
+function onFileComplete() {
+	if (queue.length > 0) {
+		const next = queue.shift()
+		parser.parse(next)
+	} else {
+		parser.emit('end')
+	}
 }
-function onFileError (e, file) {
-  e.filename = file.name
-  const at = e.stack.split('\n')[1].trim()
-  log.warn(`[${file.name}] ${e.message} ${at}, skipping…`)
-  if (checkQueue(file)) onFileComplete()
+function onFileError(e, file) {
+	e.filename = file.name
+	const at = e.stack.split('\n')[1].trim()
+	log.warn(`[${file.name}] ${e.message} ${at}, skipping…`)
+	if (checkQueue(file)) {
+		onFileComplete()
+	}
 }
-function onParserDone () {
-  return getFilesArray(cache)
+function onParserDone() {
+	return getFilesArray(cache)
     .then(renameFiles)
     .then(processFiles.bind(this, 'css', 'BEAUTIFYING YOUR STYLES…'))
     .then(processFiles.bind(this, 'js', 'CRANKING YOUR SCRIPTS…'))
@@ -101,24 +113,24 @@ function onParserDone () {
     .then(processSourceMaps)
     .then(processImages)
     .then(buildFiles)
-    .then((files) => {
-      log.success('MAGIC FINISHED')
-      parser.emit('after_build', files)
-    })
+    .then(files => {
+	log.success('MAGIC FINISHED')
+	parser.emit('after_build', files)
+})
     .catch(onError)
 }
 
 module.exports = function (index, buildDir, options = {}) {
-  // move cwd to index location
-  process.chdir(path.dirname(index))
-  index = path.basename(index || 'index.html')
+  // Move cwd to index location
+	process.chdir(path.dirname(index))
+	index = path.basename(index || 'index.html')
 
-  checkOption = checkOption.bind(this, options) // eslint-disable-line no-func-assign
+	checkOption = checkOption.bind(this, options) // eslint-disable-line no-func-assign
 
-  buildDir = path.join(cwd, buildDir)
-  buildFiles = buildFiles.bind(this, buildDir) // eslint-disable-line no-func-assign
+	buildDir = path.join(cwd, buildDir)
+	buildFiles = buildFiles.bind(this, buildDir) // eslint-disable-line no-func-assign
 
-  return parser
+	return parser
           .on('resource', onResourceFound)
           .on('ready', onFileComplete)
           .on('error', onFileError)

--- a/lib/link-rewriter.js
+++ b/lib/link-rewriter.js
@@ -3,36 +3,44 @@ const envMatch = /\$ENV\[['"]?([\w.\-/@]+?)['"]?\]/g
 
 let cache = []
 
-function adjustPath (file) {
-  const targetSrc = file.type === 'html' ? file.name : file.vname
-  return `/${targetSrc}`
+function adjustPath(file) {
+	const targetSrc = file.type === 'html' ? file.name : file.vname
+	return `/${targetSrc}`
 }
-function replaceFileTags (parent, match, link, name) {
-  const file = cache.find((f) => f.name === name)
-  if (!file) return name
-  if (link) return adjustPath(file)
+function replaceFileTags(parent, match, link, name) {
+	const file = cache.find(f => f.name === name)
+	if (!file) {
+		return name
+	}
+	if (link) {
+		return adjustPath(file)
+	}
 
-  run(file)
+	run(file)
 
-  let newContent = file.contents
+	let newContent = file.contents
 
-  // support for @filename.ext inside js files
-  if (parent.type === 'js' && file.type.match(/html|css/)) {
-    // escape //, /replace, \n, ", ' for \\$1
-    newContent = newContent.replace(/([\\/\n"'])/g, '\\$1')
-  }
-  return newContent
+  // Support for @filename.ext inside js files
+	if (parent.type === 'js' && file.type.match(/html|css/)) {
+    // Escape //, /replace, \n, ", ' for \\$1
+		newContent = newContent.replace(/([\\/\n"'])/g, '\\$1')
+	}
+	return newContent
 }
-function replaceEnvTags (m, v) { return process.env[v] || '' }
+function replaceEnvTags(m, v) {
+	return process.env[v] || ''
+}
 
-function run (file) {
-  if (!file.contents || !file.contents.replace) return file
-  file.contents = file.contents.replace(fileMatch, replaceFileTags.bind(void 0, file))
-  file.contents = file.contents.replace(envMatch, replaceEnvTags)
-  return file
+function run(file) {
+	if (!file.contents || !file.contents.replace) {
+		return file
+	}
+	file.contents = file.contents.replace(fileMatch, replaceFileTags.bind(undefined, file))
+	file.contents = file.contents.replace(envMatch, replaceEnvTags)
+	return file
 }
 
 module.exports = (resourceFiles, allFiles) => {
-  cache = allFiles
-  return Promise.all(resourceFiles.map(run))
+	cache = allFiles
+	return Promise.all(resourceFiles.map(run))
 }

--- a/lib/min/css.js
+++ b/lib/min/css.js
@@ -5,45 +5,49 @@ const postcss = require('postcss')
 const CleanCSS = require('clean-css')
 const log = require('../utils').log
 
-function autoprefix (file) {
-  return new Promise((resolve, reject) => {
-    postcss([flexfix, autoprefixer]).process(file.contents)
-      .then(function (output) {
-        file.contents = output.css
-        resolve(file)
-      }).catch(reject)
-  })
+function autoprefix(file) {
+	return new Promise((resolve, reject) => {
+		postcss([flexfix, autoprefixer]).process(file.contents)
+      .then(output => {
+	file.contents = output.css
+	resolve(file)
+}).catch(reject)
+	})
 }
-function cleanCSS (file) {
-  return new Promise((resolve, reject) => {
-    const ps = new CleanCSS({ keepSpecialComments: 0 })
-    try {
-      file.contents = ps.minify(file.contents).styles
-      resolve(file)
-    } catch (e) {
-      reject(e)
-    }
-  })
+function cleanCSS(file) {
+	return new Promise((resolve, reject) => {
+		const ps = new CleanCSS({keepSpecialComments: 0})
+		try {
+			file.contents = ps.minify(file.contents).styles
+			resolve(file)
+		} catch (err) {
+			reject(err)
+		}
+	})
 }
-function lessify (file) {
-  return new Promise((resolve, reject) => {
-    less.render(file.contents, function (e, output) {
-      if (e) { return reject(e) }
-      file.contents = output.css
-      resolve(file)
-    })
-  })
+function lessify(file) {
+	return new Promise((resolve, reject) => {
+		less.render(file.contents, (e, output) => {
+			if (e) {
+				return reject(e)
+			}
+			file.contents = output.css
+			resolve(file)
+		})
+	})
 }
-function run (file) {
-  if (!file.ext.match(/less|css/)) {
-    file.skip = true
-    log.warn(`[${file.name}]`, 'Only LESS/CSS files are supported.', 'Skipping…')
-  }
-  if (file.skip) return file
+function run(file) {
+	if (!file.ext.match(/less|css/)) {
+		file.skip = true
+		log.warn(`[${file.name}]`, 'Only LESS/CSS files are supported.', 'Skipping…')
+	}
+	if (file.skip) {
+		return file
+	}
 
-  const transpile = file.ext === 'less' ? lessify(file) : Promise.resolve(file)
-  return transpile.then(autoprefix)
+	const transpile = file.ext === 'less' ? lessify(file) : Promise.resolve(file)
+	return transpile.then(autoprefix)
                   .then(cleanCSS)
                   .catch(log.error.bind(file))
 }
-module.exports = (files) => Promise.all(files.map(run))
+module.exports = files => Promise.all(files.map(run))

--- a/lib/min/html.js
+++ b/lib/min/html.js
@@ -1,17 +1,17 @@
 const minify = require('html-minifier').minify
 const log = require('../utils').log
 
-function run (file) {
-  try {
-    file.contents = minify(file.contents, {
-      collapseWhitespace: true,
-      preserveLineBreaks: true,
-      removeComments: true,
-      removeAttributeQuotes: true
-    })
-  } catch (e) {
-    log.warn('[%s] Error minifying HTML: %s', file.name, e.message.split('\n')[0])
-  }
-  return file
+function run(file) {
+	try {
+		file.contents = minify(file.contents, {
+			collapseWhitespace: true,
+			preserveLineBreaks: true,
+			removeComments: true,
+			removeAttributeQuotes: true
+		})
+	} catch (err) {
+		log.warn('[%s] Error minifying HTML: %s', file.name, err.message.split('\n')[0])
+	}
+	return file
 }
-module.exports = (files) => Promise.all(files.map(run))
+module.exports = files => Promise.all(files.map(run))

--- a/lib/min/img.js
+++ b/lib/min/img.js
@@ -4,23 +4,26 @@ const imageminPngquant = require('imagemin-pngquant')
 const imageminSvgo = require('imagemin-svgo')
 const batchPromises = require('batch-promises')
 const log = require('../utils').log
+
 const plugins = [
-  imageminJpegtran(),
-  imageminPngquant({quality: '90'}),
-  imageminSvgo()
+	imageminJpegtran(),
+	imageminPngquant({quality: '90'}),
+	imageminSvgo()
 ]
 
-function run (file) {
-  return imagemin.buffer(file.contents, {plugins}).then((cFile) => {
-    const originalSize = file.contents.length
-    const compressedSize = cFile.length
-    const compression = 100 - Math.ceil((compressedSize * 100) / originalSize)
-    file.contents = cFile
-    if (compression) log.info('[%s] compressed in %s%', file.name, compression)
-    return file
-  }).catch((e) => {
-    e.fileName = file.name
-    throw e
-  })
+function run(file) {
+	return imagemin.buffer(file.contents, {plugins}).then(cFile => {
+		const originalSize = file.contents.length
+		const compressedSize = cFile.length
+		const compression = 100 - Math.ceil((compressedSize * 100) / originalSize)
+		file.contents = cFile
+		if (compression) {
+			log.info('[%s] compressed in %s%', file.name, compression)
+		}
+		return file
+	}).catch(err => {
+		err.fileName = file.name
+		throw err
+	})
 }
-module.exports = (files) => batchPromises(10, files, run)
+module.exports = files => batchPromises(10, files, run)

--- a/lib/min/index.js
+++ b/lib/min/index.js
@@ -1,6 +1,6 @@
 module.exports = {
-  html: require('./html'),
-  css: require('./css'),
-  js: require('./js'),
-  img: require('./img')
+	html: require('./html'),
+	css: require('./css'),
+	js: require('./js'),
+	img: require('./img')
 }

--- a/lib/min/js.js
+++ b/lib/min/js.js
@@ -8,130 +8,150 @@ const babelStage3 = require('babel-preset-stage-3')
 const uglifyjs = require('uglify-js')
 const log = require('../utils').log
 
-function getOffsetContent (file) {
-  // adjust inline script contents with the line number it was located
-  if (!file.inline) return file.contents
-  // using zero-base index to match with source map spec
-  const fmtLine = file.line ? file.line - 1 : 0
-  const fmtCol = file.column ? file.column - 1 : 0
-  return Array(fmtLine).fill('\n').join('') +
+function getOffsetContent(file) {
+  // Adjust inline script contents with the line number it was located
+	if (!file.inline) {
+		return file.contents
+	}
+  // Using zero-base index to match with source map spec
+	const fmtLine = file.line ? file.line - 1 : 0
+	const fmtCol = file.column ? file.column - 1 : 0
+	return Array(fmtLine).fill('\n').join('') +
     Array(fmtCol).fill(' ').join('') +
     file.contents
 }
-function replaceNodeEnvVars (file) {
-  const nodePattern = /process.env(?:\.(.+?)\b|\[(["'])(.+?)\2\])/g
-  file.contents = file.contents.replace(nodePattern, (m, v1, _, v3) => {
-    return `'${process.env[v1 || v3] || ''}'`
-  })
-  return Promise.resolve(file)
+function replaceNodeEnvVars(file) {
+	const nodePattern = /process.env(?:\.(.+?)\b|\[(["'])(.+?)\2\])/g
+	file.contents = file.contents.replace(nodePattern, (m, v1, _, v3) => {
+		return `'${process.env[v1 || v3] || ''}'`
+	})
+	return Promise.resolve(file)
 }
-function splitContentAndSourceMap (content) {
-  const split = content.toString().split('//# sourceMappingURL=data:application/json;charset=utf-8;base64,')
-  return {
-    contents: split[0],
-    sourceMap: Buffer.from(split[1] || '', 'base64').toString()
-  }
+function splitContentAndSourceMap(content) {
+	const split = content.toString().split('//# sourceMappingURL=data:application/json;charset=utf-8;base64,')
+	return {
+		contents: split[0],
+		sourceMap: Buffer.from(split[1] || '', 'base64').toString()
+	}
 }
-function rerouteSourceMap (file) {
-  if (!file.sourceMap) return file
-  const map = file.sourceMap = JSON.parse(file.sourceMap)
-  const base = file.parentHref || file.name
+function rerouteSourceMap(file) {
+	if (!file.sourceMap) {
+		return file
+	}
+	file.sourceMap = JSON.parse(file.sourceMap)
+	const map = file.sourceMap
+	const base = file.parentHref || file.name
 
-  map.sources = map.sources.map((source) => {
-    if (source === '_stream_0.js') return base
-    if (source.match('node_modules')) return source.split(/(?=node_modules)/)[1]
-    if (file.hasImports) return path.join(path.dirname(base), source)
-    return base
-  })
-  return file
+	map.sources = map.sources.map(source => {
+		if (source === '_stream_0.js') {
+			return base
+		}
+		if (source.match('node_modules')) {
+			return source.split(/(?=node_modules)/)[1]
+		}
+		if (file.hasImports) {
+			return path.join(path.dirname(base), source)
+		}
+		return base
+	})
+	return file
 }
-function minifyJSON (file) {
-  return new Promise((resolve, reject) => {
-    try {
-      file.contents = file.contents.replace(/\n+/g, '').replace(/(\s)+/g, '$1')
-      resolve(file)
-    } catch (e) {
-      reject(e)
-    }
-  })
+function minifyJSON(file) {
+	return new Promise((resolve, reject) => {
+		try {
+			file.contents = file.contents.replace(/\n+/g, '').replace(/(\s)+/g, '$1')
+			resolve(file)
+		} catch (err) {
+			reject(err)
+		}
+	})
 }
-function brwsrfy (file) {
-  return new Promise((resolve, reject) => {
-    const s = new stream.Readable()
-    const filePath = path.parse(process.cwd() + '/' + file.name)
-    s.push(file.contents)
-    s.push(null)
-    // send alterred file stream to browserify
-    browserify(s, { basedir: filePath.dir, debug: true })
+function brwsrfy(file) {
+	return new Promise((resolve, reject) => {
+		const s = new stream.Readable()
+		const filePath = path.parse(process.cwd() + '/' + file.name)
+		s.push(file.contents)
+		s.push(null)
+    // Send alterred file stream to browserify
+		browserify(s, {basedir: filePath.dir, debug: true})
       .transform(babelTransform, {
-        filename: file.name,
-        presets: [babelEnv, babelStage3],
-        global: true
-      })
-      .bundle(function (error, buffer) {
-        if (error) return reject(error)
-        const result = splitContentAndSourceMap(buffer)
-        file.contents = result.contents
-        file.sourceMap = result.sourceMap
-        resolve(file)
-      })
-  })
+	filename: file.name,
+	presets: [babelEnv, babelStage3],
+	global: true
+})
+      .bundle((error, buffer) => {
+	if (error) {
+		return reject(error)
+	}
+	const result = splitContentAndSourceMap(buffer)
+	file.contents = result.contents
+	file.sourceMap = result.sourceMap
+	resolve(file)
+})
+	})
 }
-function babelify (file) {
-  return new Promise((resolve, reject) => {
-    try {
-      const transpiled = babel
+function babelify(file) {
+	return new Promise((resolve, reject) => {
+		try {
+			const transpiled = babel
         .transform(getOffsetContent(file), {
-          filename: file.name,
-          presets: [babelEnv, babelStage3],
-          sourceMaps: true
-        })
-      file.sourceMap = transpiled.map
-      file.contents = transpiled.code
-      resolve(file)
-    } catch (e) {
-      reject(e)
-    }
-  })
+	filename: file.name,
+	presets: [babelEnv, babelStage3],
+	sourceMaps: true
+})
+			file.sourceMap = transpiled.map
+			file.contents = transpiled.code
+			resolve(file)
+		} catch (err) {
+			reject(err)
+		}
+	})
 }
-function uglify (file) {
-  var options = {
-    output: { inline_script: true, beautify: false },
-    sourceMap: {
-      content: file.sourceMap
+function uglify(file) {
+	const options = {
+		// eslint-disable-next-line camelcase
+		output: {inline_script: true, beautify: false},
+		sourceMap: {
+			content: file.sourceMap
       /*
-       * need to set the `url` param based on cmd option
+       * Need to set the `url` param based on cmd option
        * such as --source-map-expose=true, which will then
        * print //# sourceMapURL at the end of scripts
        */
-      //, url: `sourcemaps/${file.name}.map`
-    }
-  }
+      // , url: `sourcemaps/${file.name}.map`
+		}
+	}
 
-  return new Promise((resolve, reject) => {
-    const minified = uglifyjs.minify(file.contents, options)
-    if (minified.error) return reject(minified.error)
-    file.sourceMap = minified.map
-    file.contents = minified.code
-    resolve(file)
-  })
+	return new Promise((resolve, reject) => {
+		const minified = uglifyjs.minify(file.contents, options)
+		if (minified.error) {
+			return reject(minified.error)
+		}
+		file.sourceMap = minified.map
+		file.contents = minified.code
+		resolve(file)
+	})
 }
-function run (file) {
-  const isDependency = file.name.match(/vendor|bower_components|node_modules/)
-  // this is likely to fail to to text in strings
+function run(file) {
+	const isDependency = file.name.match(/vendor|bower_components|node_modules/)
+  // This is likely to fail to to text in strings
   // also lacking export.foo = fn
-  const isModule = file.contents.match(/module.exports/)
-  if (isDependency || isModule) return file
-  if (file.ext === 'json') return minifyJSON(file, log.error.bind(file))
-  if (file.ext === 'js') {
-    const transpile = file.hasImports ? brwsrfy(file) : babelify(file)
-    return transpile.then(replaceNodeEnvVars)
+	const isModule = file.contents.match(/module.exports/)
+	if (isDependency || isModule) {
+		return file
+	}
+	if (file.ext === 'json') {
+		return minifyJSON(file, log.error.bind(file))
+	}
+	if (file.ext === 'js') {
+		const transpile = file.hasImports ? brwsrfy(file) : babelify(file)
+		return transpile.then(replaceNodeEnvVars)
                     .then(uglify)
                     .then(rerouteSourceMap)
                     .catch(log.error.bind(file))
-  }
+	}
 
-  log.warn(`[${file.name}]`, 'Only javascript files are supported', 'Skipping…')
-  return file
+	log.warn(`[${file.name}]`, 'Only javascript files are supported', 'Skipping…')
+	return file
 }
-module.exports = (files) => Promise.all(files.map(run))
+module.exports = files => Promise.all(files.map(run))

--- a/lib/parser/css.js
+++ b/lib/parser/css.js
@@ -1,49 +1,54 @@
-/* jslint node:true */
 const path = require('path')
 const resolve = require('../utils/resolve')
 
-function sanitizeFileName (src, parentName) {
-  if (!path.extname(src)) return src + path.extname(parentName)
-  return src
+function sanitizeFileName(src, parentName) {
+	if (!path.extname(src)) {
+		return src + path.extname(parentName)
+	}
+	return src
 }
 
 exports.setContent = function (file) {
-  const imports = /@import(?: url)?[ ('"]+(.+)\b[ ('";)]+/g
-  const attrSelectors = /\[(?:src|href)[*|^?]?=(['"])?(.+?)\1?\]/g
+	const imports = /@import(?: url)?[ ('"]+(.+)\b[ ('";)]+/g
+	const attrSelectors = /\[(?:src|href)[*|^?]?=(['"])?(.+?)\1?\]/g
 
-  let content = file.contents
+	let content = file.contents
 
-  content = content.replace(imports, (m, href) => {
-    const resolved = resolve(sanitizeFileName(href, file.name))
-    if (resolved.external) return m
-    // replace entire @import file.less statement with the file contents
+	content = content.replace(imports, (m, href) => {
+		const resolved = resolve(sanitizeFileName(href, file.name))
+		if (resolved.external) {
+			return m
+		}
+    // Replace entire @import file.less statement with the file contents
     // this way, the parser doesn't need to look for files elsewhere
-    return sanitizeFileName(href, file.name)
-    // this allows proper lookup paths
+		return sanitizeFileName(href, file.name)
+    // This allows proper lookup paths
     // return m.replace(href, resolved.name);
-  })
+	})
 
-  content = content.replace(attrSelectors, function (m, sep, href) {
-    if (resolve(href).external || !href.match(/\.\w{3,5}$/)) return m
-    return m.replace(href, '__base_' + href)
-  })
+	content = content.replace(attrSelectors, (m, sep, href) => {
+		if (resolve(href).external || !href.match(/\.\w{3,5}$/)) {
+			return m
+		}
+		return m.replace(href, '__base_' + href)
+	})
 
-  return content
+	return content
 }
 
 exports.setResource = function (file) {
-  file = JSON.parse(JSON.stringify(file))
+	file = JSON.parse(JSON.stringify(file))
 
-  if (file.name.match(/^__base_/)) {
-    file.name = file.name.replace(/^__base_/, '')
-    file = resolve(file.name)
-  }
+	if (file.name.startsWith('__base_')) {
+		file.name = file.name.replace(/^__base_/, '')
+		file = resolve(file.name)
+	}
   // Skip all css import resources.
   // CSS files are supposed to be merged into the main file
   // hence, skipping and inlining
-  if (file.type === 'css') {
-    file.skip = true
-    file.inline = true
-  }
-  return file
+	if (file.type === 'css') {
+		file.skip = true
+		file.inline = true
+	}
+	return file
 }

--- a/lib/parser/general.js
+++ b/lib/parser/general.js
@@ -1,9 +1,10 @@
 const fs = require('fs')
 const utils = require('../utils')
+
 const parser = {
-  html: require('./html'),
-  css: require('./css'),
-  js: require('./js')
+	html: require('./html'),
+	css: require('./css'),
+	js: require('./js')
 }
 const resolve = utils.resolve
 const whitelist = new RegExp(utils.interpolate(
@@ -11,36 +12,46 @@ const whitelist = new RegExp(utils.interpolate(
   'jpg|png|gif|svg|ico|less|css|js|json|ld\\+json|html|xml|eot|ttf|woff|otf|pdf|vcf|md|markdown|mdown'
 ), 'ig')
 
-function sanitizeSrc (src) {
+function sanitizeSrc(src) {
   // Remove expansion flag and backslases
-  return src.replace(/^@/, '').replace(/\\/g, '')
+	return src.replace(/^@/, '').replace(/\\/g, '')
 }
 
-function onURL (href, expand) {
-  const {file, emitter} = this
-  const fileParser = parser[file.type]
-  const parentSrc = file.ext === 'js' ? '' : file.name
-  let found = resolve(sanitizeSrc(href), parentSrc)
+function onURL(href, expand) {
+	const {file, emitter} = this
+	const fileParser = parser[file.type]
+	const parentSrc = file.ext === 'js' ? '' : file.name
+	let found = resolve(sanitizeSrc(href), parentSrc)
 
-  if (found.external) return found.name
-  if (fileParser) found = fileParser.setResource(found, file)
-  if (expand) found.inline = true
+	if (found.external) {
+		return found.name
+	}
+	if (fileParser) {
+		found = fileParser.setResource(found, file)
+	}
+	if (expand) {
+		found.inline = true
+	}
 
-  /* if file exists, tokenize it otherwise re-apply original name */
-  try {
-    if (!found.contents) fs.openSync(found.name, 'r')
-    emitter.emit('resource', found)
-    const f = found.inline ? '' : 'f'
-    return `!@${f}{${found.name}}`
-  } catch (e) {
-    emitter.emit('error', e, file)
-    return href
-  }
+  /* If file exists, tokenize it otherwise re-apply original name */
+	try {
+		if (!found.contents) {
+			fs.openSync(found.name, 'r')
+		}
+		emitter.emit('resource', found)
+		const f = found.inline ? '' : 'f'
+		return `!@${f}{${found.name}}`
+	} catch (err) {
+		emitter.emit('error', err, file)
+		return href
+	}
 }
 
 module.exports = function (file, emitter) {
-  const fileParser = parser[file.type]
-  if (fileParser) file.contents = fileParser.setContent(file)
-  file.contents = file.contents.replace(whitelist, onURL.bind({file, emitter}))
-  return file
+	const fileParser = parser[file.type]
+	if (fileParser) {
+		file.contents = fileParser.setContent(file)
+	}
+	file.contents = file.contents.replace(whitelist, onURL.bind({file, emitter}))
+	return file
 }

--- a/lib/parser/html.js
+++ b/lib/parser/html.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const marked = require('marked').setOptions({smartypants: true})
 const i = require('../utils/interpolate')
+
 const validTags = new RegExp(i(
   /<(%s)\b([^>]*)>(?:([\s\S]*?)<\/\1>)?/,
   'script|link|style'
@@ -8,47 +9,53 @@ const validTags = new RegExp(i(
 const SSIPattern = /<!--#include file=["']?(.+?)["']? -->/g
 let tmpFiles
 
-function flattenAttrs (attrs) {
-  return Object.keys(attrs).map((key) => {
-    if (attrs[key] === true || !attrs[key]) return key
-    const value = (attrs[key] || '').replace(/"/g, '"')
-    return `${key}="${value}"`
-  }).join(' ')
+function flattenAttrs(attrs) {
+	return Object.keys(attrs).map(key => {
+		if (attrs[key] === true || !attrs[key]) {
+			return key
+		}
+		const value = (attrs[key] || '').replace(/"/g, '"')
+		return `${key}="${value}"`
+	}).join(' ')
 }
-function getAttrs (str) {
-  const r = {}
-  const search = /\b([\w-]+)\b=?(?:(["'])([\s\S]+?)\2|([^ ]+)|)/g
-  str.replace(search, (m, key, sep, value, altValue) => {
-    if (!value && !altValue) {
-      r[key] = true
-    } else {
-      r[key] = value || altValue
-    }
-  })
-  return r
+function getAttrs(str) {
+	const r = {}
+	const search = /\b([\w-]+)\b=?(?:(["'])([\s\S]+?)\2|([^ ]+)|)/g
+	str.replace(search, (m, key, sep, value, altValue) => {
+		if (!value && !altValue) {
+			r[key] = true
+		} else {
+			r[key] = value || altValue
+		}
+	})
+	return r
 }
-function stripCommentsExceptSSI (str) {
-  return str.replace(/<!--(?!#include)[\s\S]*?-->/gmi, '')
+function stripCommentsExceptSSI(str) {
+	return str.replace(/<!--(?!#include)[\s\S]*?-->/gmi, '')
 }
 
-function getTextIndexLineNumber (content, index) {
-  const head = content.substr(0, index).match(/\n/g)
-  if (head) return head.length + 1  // non-zero based count
-  return 1
+function getTextIndexLineNumber(content, index) {
+	const head = content.substr(0, index).match(/\n/g)
+	if (head) {
+		return head.length + 1
+	}  // Non-zero based count
+	return 1
 }
-function removeInlineAttrs (attrs) {
-  delete attrs.src
-  delete attrs.href
-  delete attrs['data-inline']
+function removeInlineAttrs(attrs) {
+	delete attrs.src
+	delete attrs.href
+	delete attrs['data-inline']
 }
-function appendFileSource (file, src) {
-  file.includes = file.includes || []
-  file.includes.push(src)
+function appendFileSource(file, src) {
+	file.includes = file.includes || []
+	file.includes.push(src)
 }
-function createImportTag (tag, src, attrs) {
-  const nodeName = tag === 'link' ? 'style' : 'script'
-  if (tag === 'link') delete attrs.rel
-  return `<${nodeName} ${flattenAttrs(attrs)}>@${src}</${nodeName}>`
+function createImportTag(tag, src, attrs) {
+	const nodeName = tag === 'link' ? 'style' : 'script'
+	if (tag === 'link') {
+		delete attrs.rel
+	}
+	return `<${nodeName} ${flattenAttrs(attrs)}>@${src}</${nodeName}>`
 }
 
 /**
@@ -58,106 +65,112 @@ function createImportTag (tag, src, attrs) {
   * @param {string} src script source
   * @param {object} attrs tag html attributes
   * @returns {string} a script tag
-**/
-function createAMDImportTag (tag, src, attrs) {
-  attrs.src = `__amd_${attrs['data-main']}`
-  if (!path.extname(attrs.src)) attrs.src += '.js'
-  delete attrs['data-main']
-  return `<script ${flattenAttrs(attrs)}></script>`
+* */
+function createAMDImportTag(tag, src, attrs) {
+	attrs.src = `__amd_${attrs['data-main']}`
+	if (!path.extname(attrs.src)) {
+		attrs.src += '.js'
+	}
+	delete attrs['data-main']
+	return `<script ${flattenAttrs(attrs)}></script>`
 }
 
-function getNameForInlineResource (tag, filename, fileType, line, column) {
-  const name = path.basename(filename).replace(path.extname(filename), '')
-  const ext = fileType || (tag === 'style' ? 'css' : 'js')
-  return `${name}-${tag}-${line}_${column}.${ext}`
+function getNameForInlineResource(tag, filename, fileType, line, column) {
+	const name = path.basename(filename).replace(path.extname(filename), '')
+	const ext = fileType || (tag === 'style' ? 'css' : 'js')
+	return `${name}-${tag}-${line}_${column}.${ext}`
 }
-function registerTagContentsAsFile (name, content, line, column) {
-  tmpFiles[name] = content
-  tmpFiles[`${name}_meta`] = { line, column }
+function registerTagContentsAsFile(name, content, line, column) {
+	tmpFiles[name] = content
+	tmpFiles[`${name}_meta`] = {line, column}
 }
-function createInlineTag (tag, src, attrs) {
-  return `<${tag} ${flattenAttrs(attrs)}>@${src}</${tag}>`
+function createInlineTag(tag, src, attrs) {
+	return `<${tag} ${flattenAttrs(attrs)}>@${src}</${tag}>`
 }
 
-function parse (match, tag, attrs, textContent, index, content) {
-  attrs = getAttrs(attrs)
+function parse(match, tag, attrs, textContent, index, content) {
+	attrs = getAttrs(attrs)
 
-  if (attrs['data-dev']) return ''
+	if (attrs['data-dev']) {
+		return ''
+	}
 
-  const file = this
-  const src = attrs.src || attrs.href
-  const inline = src && attrs['data-inline']
+	const file = this
+	const src = attrs.src || attrs.href
+	const inline = src && attrs['data-inline']
 
-  let node = match
-  let fileType
+	let node = match
+	let fileType
 
-  if (attrs.type) {
-    // parse type attribute such type=text/less
-    fileType = attrs.type.split('/')[1]
-    if (fileType === 'ld+json') {
-      fileType = 'json'
-    } else {
-      // need to remove or rename type attributes
+	if (attrs.type) {
+    // Parse type attribute such type=text/less
+		fileType = attrs.type.split('/')[1]
+		if (fileType === 'ld+json') {
+			fileType = 'json'
+		} else {
+      // Need to remove or rename type attributes
       // otherwise DOM won't interpret `text/less` correctly
-      delete attrs.type
-    }
-  }
+			delete attrs.type
+		}
+	}
 
-  if (inline) {
-    removeInlineAttrs(attrs)
-    appendFileSource(file, src)
-  }
+	if (inline) {
+		removeInlineAttrs(attrs)
+		appendFileSource(file, src)
+	}
 
-  if (tag.match(/style|script/) && textContent) {
-    const line = getTextIndexLineNumber(content, index)
-    const column = match.indexOf(textContent) + 1 // non-zero based count
-    const name = getNameForInlineResource(tag, file.name, fileType, line, column)
-    registerTagContentsAsFile(name, textContent, line, column)
-    node = createInlineTag(tag, name, attrs)
-  }
+	if (tag.match(/style|script/) && textContent) {
+		const line = getTextIndexLineNumber(content, index)
+		const column = match.indexOf(textContent) + 1 // Non-zero based count
+		const name = getNameForInlineResource(tag, file.name, fileType, line, column)
+		registerTagContentsAsFile(name, textContent, line, column)
+		node = createInlineTag(tag, name, attrs)
+	}
 
-  if (tag.match(/link|script/) && inline) {
-    node = createImportTag(tag, src, attrs)
-  }
+	if (tag.match(/link|script/) && inline) {
+		node = createImportTag(tag, src, attrs)
+	}
 
-  if (tag === 'script' && attrs['data-main']) {
-    node = createAMDImportTag(tag, src, attrs)
-  }
+	if (tag === 'script' && attrs['data-main']) {
+		node = createAMDImportTag(tag, src, attrs)
+	}
 
-  return node
+	return node
 }
 
-function parseSSI (m, filePath) {
-  const file = this
-  // assign the inclusion on the vFile
-  file.includes = file.includes || []
-  file.includes.push(filePath)
-  return `@${filePath}`
+function parseSSI(m, filePath) {
+	const file = this
+  // Assign the inclusion on the vFile
+	file.includes = file.includes || []
+	file.includes.push(filePath)
+	return `@${filePath}`
 }
 
 exports.setContent = function (file) {
-  let content = file.contents
-  // need to clean cache once it persists accross instances
-  tmpFiles = {}
+	let content = file.contents
+  // Need to clean cache once it persists accross instances
+	tmpFiles = {}
 
-  // if markdown, convert to html
-  if (path.extname(file.name) === '.md') content = marked(content)
+  // If markdown, convert to html
+	if (path.extname(file.name) === '.md') {
+		content = marked(content)
+	}
 
-  return stripCommentsExceptSSI(content)
+	return stripCommentsExceptSSI(content)
          .replace(validTags, parse.bind(file))
          .replace(SSIPattern, parseSSI.bind(file))
 }
 
 exports.setResource = function (file, parent) {
-  file = JSON.parse(JSON.stringify(file))
-  const basename = path.basename(file.name)
-  if (tmpFiles[basename]) {
-    file.contents = tmpFiles[basename]
-    file.parentHref = parent.name
-  }
-  // assign extra info added during the setContent method
-  if (tmpFiles[basename + '_meta']) {
-    Object.assign(file, tmpFiles[basename + '_meta'])
-  }
-  return file
+	file = JSON.parse(JSON.stringify(file))
+	const basename = path.basename(file.name)
+	if (tmpFiles[basename]) {
+		file.contents = tmpFiles[basename]
+		file.parentHref = parent.name
+	}
+  // Assign extra info added during the setContent method
+	if (tmpFiles[basename + '_meta']) {
+		Object.assign(file, tmpFiles[basename + '_meta'])
+	}
+	return file
 }

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -2,35 +2,47 @@ const {readFile} = require('fs')
 const {EventEmitter} = require('events')
 const sendToParser = require('./general')
 
-function getFileContents (file) {
-  return new Promise((resolve, reject) => {
-    if (file.contents) return resolve(file)
-    readFile(file.name, (err, data) => {
-      if (err) return reject(err)
-      if (file.type !== 'img' && file.type !== 'other') data = data.toString()
-      file.contents = data
-      resolve(file)
-    })
-  })
+function getFileContents(file) {
+	return new Promise((resolve, reject) => {
+		if (file.contents) {
+			return resolve(file)
+		}
+		readFile(file.name, (err, data) => {
+			if (err) {
+				return reject(err)
+			}
+			if (file.type !== 'img' && file.type !== 'other') {
+				data = data.toString()
+			}
+			file.contents = data
+			resolve(file)
+		})
+	})
 }
-function routeFile (file) {
-  // skip parsing non textual files (i.e: images)
-  if (Buffer.isBuffer(file.contents)) return file
-  return sendToParser(file, this)
+function routeFile(file) {
+  // Skip parsing non textual files (i.e: images)
+	if (Buffer.isBuffer(file.contents)) {
+		return file
+	}
+	return sendToParser(file, this)
+}
+function markFileAsDone(file) {
+	file.done = true
+	return file
 }
 
-function parse (file) {
-  getFileContents(file)
+function parse(file) {
+	getFileContents(file)
       .then(() => routeFile.call(this, file))
-      .then(() => (file.done = true))
+      .then(() => markFileAsDone(file))
       .then(() => this.emit('resource', file))
       .then(() => this.emit('ready'))
-    .catch((e) => this.emit('error', e, file))
-  return this
+    .catch(err => this.emit('error', err, file))
+	return this
 }
 
 module.exports = function () {
-  const self = new EventEmitter()
-  self.parse = parse.bind(self)
-  return self
+	const self = new EventEmitter()
+	self.parse = parse.bind(self)
+	return self
 }

--- a/lib/parser/js.js
+++ b/lib/parser/js.js
@@ -3,23 +3,23 @@ const resolve = require('../utils/resolve')
 
 exports.setContent = function (file) {
   /*
-   * replace require or import statements module names ending with
+   * Replace require or import statements module names ending with
    * .js or .json so these won't get renamed by the general parser
    */
-  const requireMatch = /require\((['"])(.*?)(?:\.js|\.json)?\1\)/gm
-  const importMatch = /import((?:.*?from)? +)(["'])(.+?)(?:\.js|\.json)?\2/gm
-  const content = file.contents
+	const requireMatch = /require\((['"])(.*?)(?:\.js|\.json)?\1\)/gm
+	const importMatch = /import((?:.*?from)? +)(["'])(.+?)(?:\.js|\.json)?\2/gm
+	const content = file.contents
 
-  if (requireMatch.test(content) || importMatch.test(content)) {
-    file.hasImports = true
-  }
+	if (requireMatch.test(content) || importMatch.test(content)) {
+		file.hasImports = true
+	}
 
-  return content.replace(requireMatch, 'require($1$2$1)')
+	return content.replace(requireMatch, 'require($1$2$1)')
                 .replace(importMatch, 'import$1$2$3$2')
 }
 exports.setResource = function (file, parent) {
-  if (path.extname(parent.parentHref || '') !== '.html') {
-    file = resolve(file.name)
-  }
-  return file
+	if (path.extname(parent.parentHref || '') !== '.html') {
+		file = resolve(file.name)
+	}
+	return file
 }

--- a/lib/sourcemaps/index.js
+++ b/lib/sourcemaps/index.js
@@ -1,113 +1,122 @@
 const {readFileSync} = require('fs')
 
-function clone (obj) { return Object.assign({}, obj) }
-function getParents (file, files) {
-  if (!file.inline) return []
-  return files.filter((f) => {
-    // remove absolute ^/ since file names come without it
-    const base = file.parentHref || file.name
-    const includes = (f.includes || []).map((i) => i.replace(/^\//, ''))
-    return includes.indexOf(base) >= 0 || f.name === base
-  })
+function clone(obj) {
+	return Object.assign({}, obj)
 }
-function getDependants (file, files) {
-  let queue = [file]
-  let parents = []
-  do {
-    const upperParents = getParents(queue.shift(), files).filter((f) => parents.indexOf(f) < 0)
-    queue = queue.concat(...upperParents)
-    parents = parents.concat(...upperParents)
-  } while (queue.length)
-  return parents
+function getParents(file, files) {
+	if (!file.inline) {
+		return []
+	}
+	return files.filter(f => {
+    // Remove absolute ^/ since file names come without it
+		const base = file.parentHref || file.name
+		const includes = (f.includes || []).map(i => i.replace(/^\//, ''))
+		return includes.indexOf(base) >= 0 || f.name === base
+	})
 }
-function analyseFiles (file, index, files) {
-  if (!file.sourceMap) return
-  if (file.inline) {
-    return getDependants(file, files).map((h) => {
-      // line and col on source mapp offset are based
+function getDependants(file, files) {
+	let queue = [file]
+	let parents = []
+	do {
+		const upperParents = getParents(queue.shift(), files).filter(f => parents.indexOf(f) < 0)
+		queue = queue.concat(...upperParents)
+		parents = parents.concat(...upperParents)
+	} while (queue.length)
+	return parents
+}
+function analyseFiles(file, index, files) {
+	if (!file.sourceMap) {
+		return
+	}
+	if (file.inline) {
+		return getDependants(file, files).map(h => {
+      // Line and col on source mapp offset are based
       // on the minified/final file, not the original
-      const lines = h.contents.substr(0, h.contents.indexOf(file.contents)).split('\n')
-      const line = lines.length - 1
-      const column = lines.pop().length
-      return {file: h.name, script: file.name, line, column}
-    })
-  } else {
-    return [{file: file.name, script: file.name}]
-  }
+			const lines = h.contents.substr(0, h.contents.indexOf(file.contents)).split('\n')
+			const line = lines.length - 1
+			const column = lines.pop().length
+			return {file: h.name, script: file.name, line, column}
+		})
+	}
+	return [{file: file.name, script: file.name}]
 }
-function flatten (p, c) {
-  if (c) p = p.concat(...c)
-  return p
+function flatten(p, c) {
+	if (c) {
+		p = p.concat(...c)
+	}
+	return p
 }
-function groupByFile (p, c) {
-  p[c.file] = p[c.file] || []
-  p[c.file].push(c)
-  p[c.file].sort((a, b) => a.line > b.line)
-  return p
+function groupByFile(p, c) {
+	p[c.file] = p[c.file] || []
+	p[c.file].push(c)
+	p[c.file].sort((a, b) => a.line > b.line)
+	return p
 }
-function expandHTMLSourceContent (source) {
-  return readFileSync(source).toString()
+function expandHTMLSourceContent(source) {
+	return readFileSync(source).toString()
 }
-function generateSection (f) {
-  const files = this
-  const file = files.find((a) => a.name === f.script)
-  const map = clone(file.sourceMap)
-  if (!file.hasImports) {
-    map.sourcesContent = map.sources.map(expandHTMLSourceContent)
-  }
-  map.sources = map.sources.map((source) => {
-    return `/${source}${source.ext === 'js' ? '' : '.js'}`
-  })
-  return {
-    offset: { line: f.line || 0, column: f.column || 0 },
-    map
-  }
+function generateSection(f) {
+	const files = this
+	const file = files.find(a => a.name === f.script)
+	const map = clone(file.sourceMap)
+	if (!file.hasImports) {
+		map.sourcesContent = map.sources.map(expandHTMLSourceContent)
+	}
+	map.sources = map.sources.map(source => {
+		return `/${source}${source.ext === 'js' ? '' : '.js'}`
+	})
+	return {
+		offset: {line: f.line || 0, column: f.column || 0},
+		map
+	}
 }
-function generateSourceMap (fileHref, sources, files) {
-  return {
-    version: 3,
-    file: fileHref,
-    sections: sources.map(generateSection, files)
-  }
+function generateSourceMap(fileHref, sources, files) {
+	return {
+		version: 3,
+		file: fileHref,
+		sections: sources.map(generateSection, files)
+	}
 }
 
-function addSourceMappingURLToSource (file, source) {
-  const sourcemapFlag = '//# sourceMappingURL='
-  let ref = `\n${sourcemapFlag}/${file.vname}\n`
-  if (source.ext === 'html') {
-    ref = `<script>${ref}</script>`
-    const marker = /<\/(body|html)>/
-    if (source.contents.match(marker)) {
-      source.contents = source.contents.replace(marker, `${ref}\n</$1>`)
-    } else {
-      source.contents = `${source.contents}\n${ref}`
-    }
-  }
-  if (source.type === 'js') source.contents += ref
-  return file
+function addSourceMappingURLToSource(file, source) {
+	const sourcemapFlag = '//# sourceMappingURL='
+	let ref = `\n${sourcemapFlag}/${file.vname}\n`
+	if (source.ext === 'html') {
+		ref = `<script>${ref}</script>`
+		const marker = /<\/(body|html)>/
+		if (source.contents.match(marker)) {
+			source.contents = source.contents.replace(marker, `${ref}\n</$1>`)
+		} else {
+			source.contents = `${source.contents}\n${ref}`
+		}
+	}
+	if (source.type === 'js') {
+		source.contents += ref
+	}
+	return file
 }
-function createVirtualFiles (map) {
-  const files = this
-  const source = files.find((f) => f.name === map.file)
-  const file = {
-    type: 'map',
-    name: `sourcemaps/${source.name}.map'`,
-    vname: `sourcemaps/${source.vname}.map`,
-    parentHref: source.name,
-    inline: source.inline,
-    skip: source.skip,
-    contents: JSON.stringify(map, null)
-  }
-  addSourceMappingURLToSource(file, source)
-  return file
+function createVirtualFiles(map) {
+	const files = this
+	const source = files.find(f => f.name === map.file)
+	const file = {
+		type: 'map',
+		name: `sourcemaps/${source.name}.map'`,
+		vname: `sourcemaps/${source.vname}.map`,
+		parentHref: source.name,
+		inline: source.inline,
+		skip: source.skip,
+		contents: JSON.stringify(map, null)
+	}
+	addSourceMappingURLToSource(file, source)
+	return file
 }
-function main (files) {
-  const r = files
+function main(files) {
+	const r = files
              .map(analyseFiles)
              .reduce(flatten, [])
              .reduce(groupByFile, {})
-  const maps = Object.keys(r).map((k) => generateSourceMap(k, r[k], files))
-  return Promise.all(maps.map(createVirtualFiles, files))
+	const maps = Object.keys(r).map(k => generateSourceMap(k, r[k], files))
+	return Promise.all(maps.map(createVirtualFiles, files))
 }
 
 module.exports = main

--- a/lib/utils/filetype.js
+++ b/lib/utils/filetype.js
@@ -1,9 +1,19 @@
-module.exports = (src) => {
-  let type = 'other'
-  if (src.match(/\.(html|xml|md|mdown|markdown)$/)) type = 'html'
-  if (src.match(/\.(png|gif|jpg|svg|ico)$/)) type = 'img'
-  if (src.match(/\.(css|less|scss|sass)$/)) type = 'css'
-  if (src.match(/\.(js|json|ld\+json)$/)) type = 'js'
-  if (src.match(/\.(txt|rtf)$/)) type = 'txt'
-  return type
+module.exports = src => {
+	let type = 'other'
+	if (src.match(/\.(html|xml|md|mdown|markdown)$/)) {
+		type = 'html'
+	}
+	if (src.match(/\.(png|gif|jpg|svg|ico)$/)) {
+		type = 'img'
+	}
+	if (src.match(/\.(css|less|scss|sass)$/)) {
+		type = 'css'
+	}
+	if (src.match(/\.(js|json|ld\+json)$/)) {
+		type = 'js'
+	}
+	if (src.match(/\.(txt|rtf)$/)) {
+		type = 'txt'
+	}
+	return type
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  resolve: require('./resolve'),
-  log: require('./log'),
-  interpolate: require('./interpolate')
+	resolve: require('./resolve'),
+	log: require('./log'),
+	interpolate: require('./interpolate')
 }

--- a/lib/utils/interpolate.js
+++ b/lib/utils/interpolate.js
@@ -1,19 +1,19 @@
 module.exports = function () {
-  let args = Array.prototype.slice.call(arguments)
+	let args = Array.prototype.slice.call(arguments)
 
-  args = args.map(function (arg) {
-    if (arg.constructor.name === 'RegExp') {
-      return arg.toString().replace(/^\/|\/$/g, '')
-    }
-    if (arg.constructor.name === 'Object') {
-      return JSON.stringify(arg)
-    }
-    return arg
-  })
+	args = args.map(arg => {
+		if (arg.constructor.name === 'RegExp') {
+			return arg.toString().replace(/^\/|\/$/g, '')
+		}
+		if (arg.constructor.name === 'Object') {
+			return JSON.stringify(arg)
+		}
+		return arg
+	})
 
-  args[0] = args[0].replace(/%s/g, function () {
-    return args.splice(1, 1) || ''
-  })
+	args[0] = args[0].replace(/%s/g, () => {
+		return args.splice(1, 1) || ''
+	})
 
-  return args.join(' ')
+	return args.join(' ')
 }

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,54 +1,70 @@
-function replace (str) {
-  const tag = /(red|green|yellow|blue|magenta|cyan|white)\(([\s\S]+?)\)/gi
-  const codes = {
-    reset: '\u001b[0m',
-    bold: '\u001b[1m',
-    italic: '\u001b[3m',
-    underline: '\u001b[4m',
-    blink: '\u001b[5m',
-    black: '\u001b[30m',
-    red: '\u001b[31m',
-    green: '\u001b[32m',
-    yellow: '\u001b[33m',
-    blue: '\u001b[34m',
-    magenta: '\u001b[35m',
-    cyan: '\u001b[36m',
-    white: '\u001b[37m'
-  }
-  str = str.replace(tag, (m, code, word) => {
-    if (codes[code]) return codes[code] + word + codes.reset
-    return word
-  })
-  return str
+function replace(str) {
+	const tag = /(red|green|yellow|blue|magenta|cyan|white)\(([\s\S]+?)\)/gi
+	const codes = {
+		reset: '\u001b[0m',
+		bold: '\u001b[1m',
+		italic: '\u001b[3m',
+		underline: '\u001b[4m',
+		blink: '\u001b[5m',
+		black: '\u001b[30m',
+		red: '\u001b[31m',
+		green: '\u001b[32m',
+		yellow: '\u001b[33m',
+		blue: '\u001b[34m',
+		magenta: '\u001b[35m',
+		cyan: '\u001b[36m',
+		white: '\u001b[37m'
+	}
+	str = str.replace(tag, (m, code, word) => {
+		if (codes[code]) {
+			return codes[code] + word + codes.reset
+		}
+		return word
+	})
+	return str
 }
-function init (type, color, args) {
-  args = Array.prototype.slice.call(args)
-  args = args.map((arg) => {
-    if (typeof arg === 'string') return replace(arg)
-    if (typeof arg === 'object') {
-      return JSON.stringify(arg, null, 2)
+function init(type, color, args) {
+	args = Array.prototype.slice.call(args)
+	args = args.map(arg => {
+		if (typeof arg === 'string') {
+			return replace(arg)
+		}
+		if (typeof arg === 'object') {
+			return JSON.stringify(arg, null, 2)
                  .replace(/\)/g, '#@#@')
                  .replace(/\\n/g, '\n')
-    }
-    return arg
-  })
+		}
+		return arg
+	})
 
-  // perhaps add expansion types
-  args[0] = args[0].replace(/%(s|d|b)/g, () => args.splice(1, 1))
+  // Perhaps add expansion types
+	args[0] = args[0].replace(/%(s|d|b)/g, () => args.splice(1, 1))
 
-  return console[type](
+	return console[type](
     replace(`${color}(${args.join(' ')})`).replace(/#@#@/g, ')')
   )
 }
 module.exports = {
-  info () { init('info', 'cyan', arguments) },
-  success () { init('log', 'green', arguments) },
-  warn () { init('warn', 'yellow', arguments) },
-  error (err = {}) {
-    err.fileName = err.fileName || this.name
-    if (err.message) err.message = err.message.split('\n')[0]
-    if (!err.message) err.message = err.extract
-    if (err.stack) err.stack = err.stack.split('\n')[1].trim()
-    init('error', 'red', [`[${err.fileName}] ${err.message} ${err.stack}`])
-  }
+	info() {
+		init('info', 'cyan', arguments)
+	},
+	success() {
+		init('log', 'green', arguments)
+	},
+	warn() {
+		init('warn', 'yellow', arguments)
+	},
+	error(err = {}) {
+		err.fileName = err.fileName || this.name
+		if (err.message) {
+			err.message = err.message.split('\n')[0]
+		}
+		if (!err.message) {
+			err.message = err.extract
+		}
+		if (err.stack) {
+			err.stack = err.stack.split('\n')[1].trim()
+		}
+		init('error', 'red', [`[${err.fileName}] ${err.message} ${err.stack}`])
+	}
 }

--- a/lib/utils/resolve.js
+++ b/lib/utils/resolve.js
@@ -8,7 +8,9 @@ const filetype = require('./filetype')
  * @param {string} src - The src attribute of a file
  * @returns {boolean} isRemote
 */
-function isRemote (src) { return /^(?:\w+:|\/\/)/.test(src) }
+function isRemote(src) {
+	return /^(?:\w+:|\/\/)/.test(src)
+}
 
 /**
  * Resolve path for file
@@ -16,27 +18,33 @@ function isRemote (src) { return /^(?:\w+:|\/\/)/.test(src) }
  * @param {string} parentSrc - parent file path
  * @returns {object} location
 */
-function main (src = '', parentSrc = '') {
-  if (isRemote(src)) return { name: src, external: true }
+function main(src = '', parentSrc = '') {
+	if (isRemote(src)) {
+		return {name: src, external: true}
+	}
 
-  if (!path.extname(src)) src += '/index.html'
-  if (path.isAbsolute(src)) {
-    src = './' + src
-  } else {
-    src = url.resolve(parentSrc, src)
-  }
+	if (!path.extname(src)) {
+		src += '/index.html'
+	}
+	if (path.isAbsolute(src)) {
+		src = './' + src
+	} else {
+		src = url.resolve(parentSrc, src)
+	}
 
-  src = path.normalize(src)
+	src = path.normalize(src)
 
-  // normalize windows paths to unix-style
-  if (platform === 'win32') src = src.replace(/\\/g, '/')
+  // Normalize windows paths to unix-style
+	if (platform === 'win32') {
+		src = src.replace(/\\/g, '/')
+	}
 
-  const r = {
-    name: src,
-    type: filetype(src),
-    ext: path.extname(src).replace('.', '')
-  }
-  return r
+	const r = {
+		name: src,
+		type: filetype(src),
+		ext: path.extname(src).replace('.', '')
+	}
+	return r
 }
 
 module.exports = main

--- a/lib/vname.js
+++ b/lib/vname.js
@@ -1,36 +1,48 @@
 const {stat} = require('fs')
 const {exec} = require('child_process')
 
-function getCommitHash (filename) {
-  return new Promise((resolve, reject) => {
-    stat('.git', (statErr) => {
-      if (statErr) return reject(statErr)
-      const cmd = `git log -1 --pretty=format:%h -- ${filename}`
-      exec(cmd, (gitErr, stdout) => {
-        if (gitErr || !stdout) return reject(gitErr)
-        resolve(stdout)
-      })
-    })
-  })
+function getCommitHash(filename) {
+	return new Promise((resolve, reject) => {
+		stat('.git', statErr => {
+			if (statErr) {
+				return reject(statErr)
+			}
+			const cmd = `git log -1 --pretty=format:%h -- ${filename}`
+			exec(cmd, (gitErr, stdout) => {
+				if (gitErr || !stdout) {
+					return reject(gitErr)
+				}
+				resolve(stdout)
+			})
+		})
+	})
 }
-function getTimestampHash (filename) {
-  return new Promise((resolve, reject) => {
-    stat(filename, (err, stats) => {
-      if (err) return reject(new Error())
-      resolve(new Date(stats.mtime).valueOf().toString(36))
-    })
-  })
+function getTimestampHash(filename) {
+	return new Promise((resolve, reject) => {
+		stat(filename, (err, stats) => {
+			if (err) {
+				return reject(new Error())
+			}
+			resolve(new Date(stats.mtime).valueOf().toString(36))
+		})
+	})
 }
-function denormalizeURL (src) { return src.replace(/\//g, '-') }
-function assignFileVname (file, hash) {
-  file.vname = denormalizeURL(file.name).replace(/\.(\w+)$/, `-${hash}.$1`)
-  if (file.type === 'html') file.vname = file.name
-  if (file.type === 'css') file.vname = file.vname.replace(file.ext, file.type)
-  return file
+function denormalizeURL(src) {
+	return src.replace(/\//g, '-')
 }
-function run (file) {
-  return getCommitHash(file.name)
+function assignFileVname(file, hash) {
+	file.vname = denormalizeURL(file.name).replace(/\.(\w+)$/, `-${hash}.$1`)
+	if (file.type === 'html') {
+		file.vname = file.name
+	}
+	if (file.type === 'css') {
+		file.vname = file.vname.replace(file.ext, file.type)
+	}
+	return file
+}
+function run(file) {
+	return getCommitHash(file.name)
     .catch(getTimestampHash.bind(this, file.parentHref || file.name))
     .then(assignFileVname.bind(this, file))
 }
-module.exports = (files) => Promise.all(files.map(run))
+module.exports = files => Promise.all(files.map(run))

--- a/package.json
+++ b/package.json
@@ -1,25 +1,24 @@
 {
   "name": "pakku",
-  "version": "1.4.0",
   "description": "All-in-one web bundler and compiler",
-  "keywords": [
-    "web",
-    "bundling",
-    "package",
-    "compression",
-    "html",
-    "performance",
-    "automation"
-  ],
-  "author": "Marcus Zanona <zanona@me.com>",
+  "author": "Marcus Zanona <marcus@zanona.co>",
   "homepage": "https://github.com/zanona/pakku",
-  "engines": {
-    "node": ">=6",
-    "npm": ">=5"
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zanona/pakku.git"
   },
+  "bugs": {
+    "url": "https://github.com/zanona/pakku/issues"
+  },
+  "version": "1.4.0",
   "main": "lib/index.js",
   "bin": {
     "pakku": "bin/pakku.js"
+  },
+  "scripts": {
+    "precommit": "lint-staged",
+    "test": "xo && nyc ava test/{unit,functional} -v",
+    "test:local": "xo && ava test/{unit,functional} -v"
   },
   "dependencies": {
     "autoprefixer": "^7.2.3",
@@ -44,19 +43,25 @@
   },
   "devDependencies": {
     "ava": "^0.24.0",
+    "husky": "^0.14.3",
+    "lint-staged": "^6.0.0",
     "mock-fs": "^4.4.2",
-    "nyc": "^11.4.1"
+    "nyc": "^11.4.1",
+    "prettier-package-json": "^1.4.0",
+    "xo": "^0.18.2"
   },
-  "scripts": {
-    "test:local": "ava test/{unit,functional} -v",
-    "test": "nyc ava test/{unit,functional} -v"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:zanona/pakku.git"
-  },
-  "bugs": {
-    "url": "https://github.com/zanona/pakku/issues"
+  "keywords": [
+    "automation",
+    "bundling",
+    "compression",
+    "html",
+    "package",
+    "performance",
+    "web"
+  ],
+  "engines": {
+    "node": ">=6",
+    "npm": ">=5"
   },
   "licenses": [
     {
@@ -67,5 +72,28 @@
       "type": "MIT",
       "url": "https://github.com/zanona/pakku/blob/master/LICENSE"
     }
-  ]
+  ],
+  "lint-staged": {
+    "package.json": [
+      "prettier-package-json --write",
+      "git add"
+    ],
+    "*.js": [
+      "xo --fix",
+      "git add"
+    ]
+  },
+  "xo": {
+    "semicolon": false,
+    "rules": {
+      "complexity": [
+        "warn",
+        6
+      ],
+      "max-statements": [
+        "warn",
+        30
+      ]
+    }
+  }
 }

--- a/test/functional/default.js
+++ b/test/functional/default.js
@@ -1,9 +1,10 @@
-const fs = require('fs')
-const path = require('path')
-const {test} = require('ava')
-const mock = require('mock-fs')
-const pakku = require('../../lib')
-const db = require('../lib/files')
+import fs from 'fs'
+import path from 'path'
+import mock from 'mock-fs'
+import test from 'ava'
+import pakku from '../../lib'
+import db from '../lib/files'
+
 const CWD = process.cwd()
 const BASE_DIR = 'src/'
 const TARGET_FILE = path.join(BASE_DIR, 'index.html')
@@ -12,26 +13,28 @@ const BUILD_DIR = 'build'
 let cache
 
 test.before('setting up fs', mock.bind(this, db.generateFiles(BASE_DIR)))
-test.cb.before('running pakku', (t) => {
-  pakku(TARGET_FILE, BUILD_DIR, {sourcemaps: true})
-    .on('after_build', (c) => {
-      cache = c
-      t.end()
-    })
+test.cb.before('running pakku', t => {
+	pakku(TARGET_FILE, BUILD_DIR, {sourcemaps: true})
+    .on('after_build', c => {
+	cache = c
+	t.end()
+})
     .on('fatal', t.end)
 })
-test.beforeEach((t) => (t.context.cache = cache))
-
-test.cb('check for target build directory', (t) => {
-  fs.stat(`${CWD}/${BUILD_DIR}`, t.end)
+test.beforeEach(t => {
+	t.context.cache = cache
 })
 
-test('check file structure', (t) => {
-  const cachedFiles = Object.values(t.context.cache)
-  t.plan(cachedFiles.length)
-  cachedFiles.forEach(({vname}) => {
-    t.notThrows(fs.statSync.bind(this, `${BUILD_DIR}/${vname}`))
-  })
+test.cb('check for target build directory', t => {
+	fs.stat(`${CWD}/${BUILD_DIR}`, t.end)
+})
+
+test('check file structure', t => {
+	const cachedFiles = Object.values(t.context.cache)
+	t.plan(cachedFiles.length)
+	cachedFiles.forEach(({vname}) => {
+		t.notThrows(fs.statSync.bind(this, `${BUILD_DIR}/${vname}`))
+	})
 })
 
 test.after('cleaning up fs', mock.restore)

--- a/test/lib/file-cacher.js
+++ b/test/lib/file-cacher.js
@@ -1,5 +1,5 @@
 /**
-  * mock-fs doesn't support aliasing real files
+  * Mock-fs doesn't support aliasing real files
   * This script allows caching those in memory previously to
   * importing mock-fs
   * source: https://github.com/tschaub/mock-fs/issues/62#issuecomment-179854354
@@ -8,22 +8,22 @@ const fs = require('fs')
 const path = require('path')
 
 /**
- * loads all files from specific directory and assign their contents
+ * Loads all files from specific directory and assign their contents
  * to a dictionary object
  * @param {string} dir to lookup files
  * @param {object} obj to expand file contents
  * @returns {void}
  */
-function attachFilesFromDirToObj (dir, obj) {
-  fs.readdirSync(dir).forEach(function (basename) {
-    const filename = path.join(dir, basename)
-    const stat = fs.statSync(filename)
-    if (stat.isDirectory()) {
-      process(obj, dir, basename)
-    } else {
-      obj[basename] = readFile(filename)
-    }
-  })
+function attachFilesFromDirToObj(dir, obj) {
+	fs.readdirSync(dir).forEach(basename => {
+		const filename = path.join(dir, basename)
+		const stat = fs.statSync(filename)
+		if (stat.isDirectory()) {
+			process(obj, dir, basename)
+		} else {
+			obj[basename] = readFile(filename)
+		}
+	})
 }
 /**
  * Function to traverse the directory tree
@@ -32,11 +32,12 @@ function attachFilesFromDirToObj (dir, obj) {
  * @param {String} dir  - dirname
  * @returns {void}
  */
-function process (obj, root, dir) {
-  const dirname = dir ? path.join(root, dir) : root
-  const name = dir || root
-  const additionObj = obj[name] = {}
-  attachFilesFromDirToObj(dirname, additionObj)
+function process(obj, root, dir) {
+	const dirname = dir ? path.join(root, dir) : root
+	const name = dir || root
+	obj[name] = {}
+	const additionObj = obj[name]
+	attachFilesFromDirToObj(dirname, additionObj)
 }
 /**
  * Helper for reading file.
@@ -44,12 +45,12 @@ function process (obj, root, dir) {
  * @param {String} filename - filename
  * @returns {*} file contents
  */
-function readFile (filename) {
-  const ext = path.extname(filename)
-  if (['.gif', '.png', '.jpg', '.jpeg', '.svg'].indexOf(ext) !== -1) {
-    return fs.readFileSync(filename)
-  }
-  return fs.readFileSync(filename, 'utf-8')
+function readFile(filename) {
+	const ext = path.extname(filename)
+	if (['.gif', '.png', '.jpg', '.jpeg', '.svg'].indexOf(ext) !== -1) {
+		return fs.readFileSync(filename)
+	}
+	return fs.readFileSync(filename, 'utf-8')
 }
 module.exports = {
   /**
@@ -57,11 +58,11 @@ module.exports = {
    * @param {String} dir – filename of directory (full path to directory)
    * @returns {Object} - object with duplicating fs
    */
-  duplicateFSInMemory: function (dir) {
-    const obj = {}
-    attachFilesFromDirToObj(dir, obj)
-    return obj
-  },
+	duplicateFSInMemory(dir) {
+		const obj = {}
+		attachFilesFromDirToObj(dir, obj)
+		return obj
+	},
 
   /**
    * 1. Remove all css comments, because they going to remove after @import stylus
@@ -69,11 +70,11 @@ module.exports = {
    * @param {String} contents - file contents
    * @returns {String} - normalized file contents
    */
-  normalizeFile: function (contents) {
-    return contents
-      .replace(/(\r\n|\n|\r)/gm, '') // remove line breaks
-      .replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm, '') // spaces
+	normalizeFile(contents) {
+		return contents
+      .replace(/(\r\n|\n|\r)/gm, '') // Remove line breaks
+      .replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm, '') // Spaces
       .trim()
-  },
-  readFile: readFile
+	},
+	readFile
 }

--- a/test/lib/files.js
+++ b/test/lib/files.js
@@ -1,34 +1,38 @@
 const path = require('path')
 const fileCacher = require('./file-cacher.js')
+
 const nodeModules = fileCacher.duplicateFSInMemory('node_modules')
-function rebasePathForFiles (files, baseDir) {
-  return Object.keys(files).reduce((p, c) => {
-    const f = files[c]
-    if (baseDir && c !== 'node_modules') c = path.join(baseDir, c)
-    p[c] = f
-    return p
-  }, {})
+function rebasePathForFiles(files, baseDir) {
+	return Object.keys(files).reduce((p, c) => {
+		const f = files[c]
+		if (baseDir && c !== 'node_modules') {
+			c = path.join(baseDir, c)
+		}
+		p[c] = f
+		return p
+	}, {})
 }
-exports.generateFiles = (baseDir) => {
-  const files = {
-    node_modules: nodeModules,
-    'index.html': `
-      <link rel=stylesheet href=lib/meta/index.less>
-      <script src=lib/meta/index.js></script>
-    `,
-    'lib/meta/index.js': `
-      const msg = 'hello world';
-      console.log(\`\${msg}\`);
-    `,
-    'lib/meta/picture.svg': `
-      <svg viewBox='0 0 100 100' version='1.1' xmlns='http://www.w3.org/2000/svg'>
-        <circle fill='#000000' cx='50' cy='50' r='50'></circle>
-      </svg>
-    `,
-    'lib/meta/index.less': `
-      @color: red;
-      body{ background: @color url(picture.svg); }
-    `
-  }
-  return rebasePathForFiles(files, baseDir)
+exports.generateFiles = baseDir => {
+	const files = {
+		// eslint-disable-next-line camelcase
+		node_modules: nodeModules,
+		'index.html': `
+		  <link rel=stylesheet href=lib/meta/index.less>
+		  <script src=lib/meta/index.js></script>
+		`,
+		'lib/meta/index.js': `
+		  const msg = 'hello world';
+		  console.log(\`\${msg}\`);
+		`,
+		'lib/meta/picture.svg': `
+		  <svg viewBox='0 0 100 100' version='1.1' xmlns='http://www.w3.org/2000/svg'>
+			<circle fill='#000000' cx='50' cy='50' r='50'></circle>
+		  </svg>
+		`,
+		'lib/meta/index.less': `
+		  @color: red;
+		  body{ background: @color url(picture.svg); }
+	    `
+	}
+	return rebasePathForFiles(files, baseDir)
 }

--- a/test/unit/parser-html.js
+++ b/test/unit/parser-html.js
@@ -1,10 +1,10 @@
-const {test} = require('ava')
-const html = require('../../lib/parser/html')
+import test from 'ava'
+import html from '../../lib/parser/html'
 
-test('should strip rel atrr from expanded style tags', (t) => {
-  const content = html.setContent({
-    name: 'index.html',
-    contents: '<link data-inline rel=stylesheet href=index.less>'
-  })
-  t.false(/rel=["']?stylesheet["']?/.test(content))
+test('should strip rel atrr from expanded style tags', t => {
+	const content = html.setContent({
+		name: 'index.html',
+		contents: '<link data-inline rel=stylesheet href=index.less>'
+	})
+	t.false(/rel=["']?stylesheet["']?/.test(content))
 })

--- a/test/unit/utils-resolve.js
+++ b/test/unit/utils-resolve.js
@@ -1,22 +1,22 @@
-const {test} = require('ava')
-const resolve = require('../../lib/utils/resolve')
+import test from 'ava'
+import resolve from '../../lib/utils/resolve'
 
 let path
 
-test('should define remote URLs as external', (t) => {
-  t.true(resolve('//data/products.json').external)
-  t.true(resolve('http://data/products.json').external)
+test('should define remote URLs as external', t => {
+	t.true(resolve('//data/products.json').external)
+	t.true(resolve('http://data/products.json').external)
 })
-test('should define email links as external', (t) => {
-  t.true(resolve('mailto:email@example.com').external)
+test('should define email links as external', t => {
+	t.true(resolve('mailto:email@example.com').external)
 })
-test('should normalize absolute paths', (t) => {
-  path = resolve('/data/products.json', 'lib/products/index.html')
-  t.is(path.name, 'data/products.json')
+test('should normalize absolute paths', t => {
+	path = resolve('/data/products.json', 'lib/products/index.html')
+	t.is(path.name, 'data/products.json')
 })
-test('should stack relative paths', (t) => {
-  path = resolve('icons.woff', 'lib/fonts/index.less')
-  t.is(path.name, 'lib/fonts/icons.woff')
-  path = resolve('lib/utils.less', 'lib/similar/index.less')
-  t.is(path.name, 'lib/similar/lib/utils.less')
+test('should stack relative paths', t => {
+	path = resolve('icons.woff', 'lib/fonts/index.less')
+	t.is(path.name, 'lib/fonts/icons.woff')
+	path = resolve('lib/utils.less', 'lib/similar/index.less')
+	t.is(path.name, 'lib/similar/lib/utils.less')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,11 +55,29 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
 acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-ajv@^4.9.1:
+acorn@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+ajv-keywords@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+
+ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
@@ -84,6 +102,14 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -100,7 +126,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -110,12 +136,20 @@ ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
+any-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -258,6 +292,10 @@ attempt-x@^1.1.0, attempt-x@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/attempt-x/-/attempt-x-1.1.1.tgz#fba64e96ce03c3e0bd92c92622061c4df387cb76"
 
+author-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
+
 auto-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-1.1.0.tgz#93b864dc7ee01a326281775d5c75ca0a751e5961"
@@ -379,7 +417,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -1185,7 +1223,7 @@ buffer@^5.0.2:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1221,6 +1259,16 @@ call-matcher@^1.0.0:
 call-signature@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -1302,7 +1350,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.3.0:
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -1336,6 +1384,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
 clean-css@4.1.x, clean-css@^4.1.9:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
@@ -1354,15 +1406,32 @@ cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
 cli-spinners@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.1.0.tgz#f1847b168844d917a671eb9d147e3df497c90d06"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-truncate@^1.0.0:
   version "1.1.0"
@@ -1370,6 +1439,10 @@ cli-truncate@^1.0.0:
   dependencies:
     slice-ansi "^1.0.0"
     string-width "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1462,6 +1535,10 @@ commander@2.12.x, commander@~2.12.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.1.tgz#468635c4168d06145b9323356d1da84d14ac4a7a"
 
+commander@^2.11.0, commander@^2.9.0:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
 commander@~2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -1487,6 +1564,14 @@ concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@~1.5.0, concat-stream@
     inherits "~2.0.1"
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
+
+concat-stream@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 concordance@^3.0.0:
   version "3.0.0"
@@ -1533,6 +1618,10 @@ constants-browserify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
 convert-source-map@^1.1.1, convert-source-map@^1.2.0, convert-source-map@^1.3.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
@@ -1559,6 +1648,15 @@ core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^3.0.0"
+    require-from-string "^2.0.1"
 
 create-ecdh@^4.0.0:
   version "4.0.0"
@@ -1593,7 +1691,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^4:
+cross-spawn@^4, cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
@@ -1674,11 +1772,21 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1702,7 +1810,7 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@^2.2.0, debug@^2.6.8:
+debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1778,6 +1886,16 @@ decompress@^3.0.0:
     vinyl-assign "^1.0.1"
     vinyl-fs "^2.2.0"
 
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+
+deep-assign@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-1.0.0.tgz#b092743be8427dc621ea0067cdec7e70dd19f37b"
+  dependencies:
+    is-obj "^1.0.0"
+
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -1785,6 +1903,16 @@ deep-equal@^1.0.0:
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deep-strict-equal@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz#4a078147a8ab57f6a0d4f5547243cd22f44eb4e4"
+  dependencies:
+    core-assert "^0.2.0"
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -1802,6 +1930,18 @@ define-properties@^1.1.2:
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1855,6 +1995,19 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
+  dependencies:
+    esutils "^2.0.2"
 
 dom-serializer@0:
   version "0.1.0"
@@ -1954,6 +2107,10 @@ electron-to-chromium@^1.3.28:
   version "1.3.28"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
@@ -1979,6 +2136,12 @@ end-of-stream@^1.0.0:
   dependencies:
     once "^1.4.0"
 
+enhance-visitors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
+  dependencies:
+    lodash "^4.13.1"
+
 entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
@@ -1993,7 +2156,7 @@ errno@^0.1.1:
   dependencies:
     prr "~0.0.0"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -2017,13 +2180,193 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.37"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.37.tgz#0ee741d148b80069ba27d020393756af257defc3"
+  dependencies:
+    es6-iterator "~2.0.1"
+    es6-symbol "~3.1.1"
+
 es6-error@^4.0.1, es6-error@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
 
+es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-config-xo@^0.18.0:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.18.2.tgz#0a157120875619929e735ffd6b185c41e8a187af"
+
+eslint-formatter-pretty@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz#985d9e41c1f8475f4a090c5dbd2dfcf2821d607e"
+  dependencies:
+    ansi-escapes "^2.0.0"
+    chalk "^2.1.0"
+    log-symbols "^2.0.0"
+    plur "^2.1.2"
+    string-width "^2.0.0"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
+  dependencies:
+    debug "^2.6.8"
+    resolve "^1.2.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-ava@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ava/-/eslint-plugin-ava-4.4.0.tgz#c1866e1f62e70daf2b7b5f60cfbc53bfe267a717"
+  dependencies:
+    arrify "^1.0.1"
+    deep-strict-equal "^0.2.0"
+    enhance-visitors "^1.0.0"
+    espree "^3.1.3"
+    espurify "^1.5.0"
+    import-modules "^1.1.0"
+    multimatch "^2.1.0"
+    pkg-up "^2.0.0"
+
+eslint-plugin-import@^2.0.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+
+eslint-plugin-no-use-extend-native@^0.3.2:
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz#3ad9a00c2df23b5d7f7f6be91550985a4ab701ea"
+  dependencies:
+    is-get-set-prop "^1.0.0"
+    is-js-type "^2.0.0"
+    is-obj-prop "^1.0.0"
+    is-proto-prop "^1.0.0"
+
+eslint-plugin-promise@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
+
+eslint-plugin-unicorn@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.2.tgz#99dffe9f4773b04bc39356a7febd64dd700274bc"
+  dependencies:
+    import-modules "^1.1.0"
+    lodash.camelcase "^4.1.1"
+    lodash.kebabcase "^4.0.1"
+    lodash.snakecase "^4.0.1"
+    lodash.upperfirst "^4.2.0"
+
+eslint@^3.18.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
 
 espower-location-detector@^1.0.0:
   version "1.0.0"
@@ -2034,23 +2377,50 @@ espower-location-detector@^1.0.0:
     source-map "^0.5.0"
     xtend "^4.0.0"
 
+espree@^3.1.3, espree@^3.4.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+  dependencies:
+    acorn "^5.2.1"
+    acorn-jsx "^3.0.0"
+
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-espurify@^1.6.0:
+espurify@^1.5.0, espurify@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/espurify/-/espurify-1.7.0.tgz#1c5cf6cbccc32e6f639380bd4f991fab9ba9d226"
   dependencies:
     core-js "^2.0.0"
 
-estraverse@^4.0.0, estraverse@^4.1.1:
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  dependencies:
+    estraverse "^4.1.0"
+    object-assign "^4.0.1"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 events@~1.1.0:
   version "1.1.1"
@@ -2080,9 +2450,33 @@ exec-series@^1.0.0:
     async-each-series "^1.1.0"
     object-assign "^4.1.0"
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -2097,6 +2491,10 @@ executable@^1.0.0:
   resolved "https://registry.yarnpkg.com/executable/-/executable-1.1.0.tgz#877980e9112f3391066da37265de7ad8434ab4d9"
   dependencies:
     meow "^3.1.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -2141,13 +2539,17 @@ fast-diff@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
 fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   dependencies:
     pend "~1.2.0"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2159,6 +2561,13 @@ figures@^2.0.0:
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 file-type@^3.1.0:
   version "3.9.0"
@@ -2216,6 +2625,10 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2241,6 +2654,15 @@ find-versions@^1.0.0:
 first-chunk-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 fn-name@^2.0.0:
   version "2.0.1"
@@ -2278,6 +2700,14 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2328,9 +2758,23 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+generate-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
+
+generate-object-property@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  dependencies:
+    is-property "^1.0.0"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-port@^3.0.0:
   version "3.2.0"
@@ -2342,9 +2786,24 @@ get-proxy@^1.0.1:
   dependencies:
     rc "^1.1.2"
 
+get-set-props@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-set-props/-/get-set-props-0.1.0.tgz#998475c178445686d0b32246da5df8dbcfbe8ea3"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -2399,7 +2858,7 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2416,9 +2875,20 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-globals@^9.18.0:
+globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^6.0.0, globby@^6.1.0:
   version "6.1.0"
@@ -2472,7 +2942,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2717,6 +3187,14 @@ hullabaloo-config-manager@^1.1.0:
     resolve-from "^3.0.0"
     safe-buffer "^5.0.1"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -2724,6 +3202,10 @@ ieee754@^1.1.4:
 ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+
+ignore@^3.2.0, ignore@^3.2.6:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 image-size@~0.5.0:
   version "0.5.5"
@@ -2775,6 +3257,10 @@ import-local@^0.1.1:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
+import-modules@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-1.1.0.tgz#748db79c5cc42bb9701efab424f894e72600e9dc"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -2822,6 +3308,24 @@ inline-source-map@~0.6.0:
   dependencies:
     source-map "~0.5.3"
 
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
 insert-module-globals@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.0.1.tgz#c03bf4e01cb086d5b5e5ace8ad0afe7889d638c3"
@@ -2834,6 +3338,10 @@ insert-module-globals@^7.0.0:
     process "~0.11.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+interpret@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2:
   version "2.2.2"
@@ -2897,7 +3405,7 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
-is-ci@^1.0.7:
+is-ci@^1.0.10, is-ci@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
@@ -2906,6 +3414,10 @@ is-ci@^1.0.7:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -2929,7 +3441,7 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-extglob@^2.1.0:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -2979,6 +3491,13 @@ is-generator-fn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
 
+is-get-set-prop@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz#2731877e4d78a6a69edcce6bb9d68b0779e76312"
+  dependencies:
+    get-set-props "^0.1.0"
+    lowercase-keys "^1.0.0"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -2990,6 +3509,12 @@ is-glob@^3.1.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-gzip@^1.0.0:
   version "1.0.0"
@@ -3015,6 +3540,21 @@ is-installed-globally@^0.1.0:
 is-jpg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-jpg/-/is-jpg-1.0.0.tgz#2959c17e73430db38264da75b90dd54f2d86da1c"
+
+is-js-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-js-type/-/is-js-type-2.0.0.tgz#73617006d659b4eb4729bba747d28782df0f7e22"
+  dependencies:
+    js-types "^1.0.0"
+
+is-my-json-valid@^2.10.0:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz#3da98914a70a22f0a8563ef1511a246c6fc55471"
+  dependencies:
+    generate-function "^2.0.0"
+    generate-object-property "^1.1.0"
+    jsonpointer "^4.0.0"
+    xtend "^4.0.0"
 
 is-nan-x@^1.0.1:
   version "1.0.1"
@@ -3047,7 +3587,14 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-obj@^1.0.0:
+is-obj-prop@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj-prop/-/is-obj-prop-1.0.0.tgz#b34de79c450b8d7c73ab2cdf67dc875adb85f80e"
+  dependencies:
+    lowercase-keys "^1.0.0"
+    obj-props "^1.0.0"
+
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
@@ -3069,6 +3616,16 @@ is-observable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.0.0.tgz#b77c3ffd4bea2175bdbc3ffac0f7b349d3e02c92"
   dependencies:
     symbol-observable "^1.0.4"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  dependencies:
+    is-path-inside "^1.0.0"
 
 is-path-inside@^1.0.0:
   version "1.0.0"
@@ -3096,6 +3653,17 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-property@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+
+is-proto-prop@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-proto-prop/-/is-proto-prop-1.0.0.tgz#b3951f95c089924fb5d4fcda6542ab3e83e2b220"
+  dependencies:
+    lowercase-keys "^1.0.0"
+    proto-props "^0.2.0"
+
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
@@ -3106,9 +3674,17 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
 is-relative@^0.1.0:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.1.3.tgz#905fee8ae86f45b3ec614bc3c15c869df0876e82"
+
+is-resolvable@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
@@ -3160,7 +3736,7 @@ isarray@0.0.1, isarray@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -3225,6 +3801,19 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+
+jest-validate@^21.1.0:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^21.2.0"
+    leven "^2.1.0"
+    pretty-format "^21.2.1"
+
 jpegtran-bin@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz#f60ecf4ae999c0bdad2e9fbcdf2b6f0981e7a29b"
@@ -3241,7 +3830,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.8.2, js-yaml@~3.10.0:
+js-types@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/js-types/-/js-types-1.0.0.tgz#d242e6494ed572ad3c92809fc8bed7f7687cbf03"
+
+js-yaml@^3.5.1, js-yaml@^3.8.2, js-yaml@^3.9.0, js-yaml@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3284,6 +3877,12 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3291,6 +3890,10 @@ jsonify@~0.0.0:
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+
+jsonpointer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3366,11 +3969,95 @@ less@^2.7.3:
     request "2.81.0"
     source-map "^0.5.3"
 
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 lexical-scope@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/lexical-scope/-/lexical-scope-1.2.0.tgz#fcea5edc704a4b3a8796cdca419c3a0afaf22df4"
   dependencies:
     astw "^2.0.0"
+
+lint-staged@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-6.0.0.tgz#7ab7d345f2fe302ff196f1de6a005594ace03210"
+  dependencies:
+    app-root-path "^2.0.0"
+    chalk "^2.1.0"
+    commander "^2.11.0"
+    cosmiconfig "^3.1.0"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    execa "^0.8.0"
+    find-parent-dir "^0.3.0"
+    is-glob "^4.0.0"
+    jest-validate "^21.1.0"
+    listr "^0.13.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    staged-git-files "0.0.4"
+    stringify-object "^3.2.0"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.13.0.tgz#20bb0ba30bae660ee84cc0503df4be3d5623887d"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-observable "^0.2.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.4.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.4.2"
+    stream-to-observable "^0.2.0"
+    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -3434,6 +4121,10 @@ lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
 
+lodash.camelcase@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -3441,6 +4132,10 @@ lodash.clonedeep@^4.5.0:
 lodash.clonedeepwith@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz#6ee30573a03a1a60d670a62ef33c10cf1afdbdd4"
+
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
 lodash.debounce@^4.0.3:
   version "4.0.8"
@@ -3472,13 +4167,17 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
+lodash.isequal@^4.0.0, lodash.isequal@^4.4.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isnull@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnull/-/lodash.isnull-3.0.0.tgz#fafbe59ea1dca27eed786534039dd84c2e07c56e"
+
+lodash.kebabcase@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -3499,6 +4198,10 @@ lodash.merge@^4.6.0:
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+
+lodash.snakecase@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
 
 lodash.template@^3.0.0:
   version "3.6.2"
@@ -3521,9 +4224,32 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
-lodash@^4.17.4:
+lodash.upperfirst@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.1.0.tgz#f35fa60e278832b538dc4dddcbb478a45d3e3be6"
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 logalot@^2.0.0:
   version "2.1.0"
@@ -3643,7 +4369,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-meow@^3.1.0, meow@^3.3.0, meow@^3.5.0, meow@^3.7.0:
+meow@^3.1.0, meow@^3.3.0, meow@^3.4.2, meow@^3.5.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -3721,7 +4447,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -3784,6 +4510,10 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
 nan-x@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/nan-x/-/nan-x-1.0.0.tgz#0ee78e8d1cd0592d5b4260a5940154545c61c121"
@@ -3791,6 +4521,10 @@ nan-x@^1.0.0:
 nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 ncname@1.0.x:
   version "1.0.0"
@@ -3840,6 +4574,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -3858,11 +4596,25 @@ normalize-space-x@^3.0.0:
     trim-x "^3.0.0"
     white-space-x "^3.0.0"
 
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -3922,6 +4674,10 @@ nyc@^11.4.1:
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+obj-props@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/obj-props/-/obj-props-1.1.0.tgz#626313faa442befd4a44e9a02c3cb6bde937b511"
 
 object-assign@^2.0.0:
   version "2.1.1"
@@ -4011,6 +4767,26 @@ option-chain@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/option-chain/-/option-chain-1.0.0.tgz#938d73bd4e1783f948d34023644ada23669e30f2"
 
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 ordered-read-streams@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz#7137e69b3298bb342247a1bbee3881c80e2fd78b"
@@ -4062,6 +4838,10 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 p-pipe@^1.1.0:
   version "1.2.0"
@@ -4117,6 +4897,12 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-author@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-author/-/parse-author-2.0.0.tgz#d3460bf1ddd0dfaeed42da754242e65fb684a81f"
+  dependencies:
+    author-regex "^1.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -4140,6 +4926,12 @@ parse-json@^2.1.0, parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
+  dependencies:
+    error-ex "^1.3.1"
 
 parse-ms@^0.1.0:
   version "0.1.2"
@@ -4171,7 +4963,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -4266,11 +5058,21 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
+
 plur@^2.0.0, plur@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
   dependencies:
     irregular-plurals "^1.0.0"
+
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
 pngquant-bin@^3.0.0:
   version "3.1.1"
@@ -4298,6 +5100,10 @@ postcss@^6.0.1, postcss@^6.0.14:
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -4305,6 +5111,25 @@ prepend-http@^1.0.1:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier-package-json@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/prettier-package-json/-/prettier-package-json-1.4.0.tgz#ecf2ed04c5bf9cb6926900be6260f0f9a485e2f3"
+  dependencies:
+    commander "^2.9.0"
+    fs-extra "^3.0.1"
+    glob "^7.1.2"
+    minimatch "^3.0.4"
+    parse-author "^2.0.0"
+    sort-object-keys "^1.1.2"
+    sort-order "^1.0.1"
+
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 pretty-ms@^0.2.1:
   version "0.2.2"
@@ -4331,6 +5156,10 @@ process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -4343,6 +5172,10 @@ property-is-enumerable-x@^1.1.0:
   dependencies:
     to-object-x "^1.4.1"
     to-property-key-x "^2.0.1"
+
+proto-props@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/proto-props/-/proto-props-0.2.1.tgz#5e01dc2675a0de9abfa76e799dfa334d6f483f4b"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -4467,7 +5300,7 @@ read-pkg@^2.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -4507,6 +5340,20 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -4649,6 +5496,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -4663,11 +5514,28 @@ require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
 
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+resolve-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-1.0.0.tgz#4eaeea41ed040d1702457df64a42b2b07d246f9f"
+  dependencies:
+    resolve-from "^2.0.0"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve-from@^2.0.0:
   version "2.0.0"
@@ -4681,11 +5549,18 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.4:
+resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -4700,7 +5575,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.6, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -4712,6 +5587,22 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  dependencies:
+    once "^1.3.0"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+
+rxjs@^5.4.2:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -4792,6 +5683,14 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shelljs@^0.7.5:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -4799,6 +5698,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slice-ansi@^1.0.0:
   version "1.0.0"
@@ -4816,11 +5719,25 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+sort-keys@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
   dependencies:
     is-plain-obj "^1.0.0"
+
+sort-object-keys@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.2.tgz#d3a6c48dc2ac97e6bc94367696e03f6d09d37952"
+
+sort-order@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sort-order/-/sort-order-1.0.1.tgz#d822b8cdb90ea6a9df968c4bd45987cf548199e6"
 
 source-map-support@^0.4.15:
   version "0.4.18"
@@ -4911,6 +5828,10 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 stat-mode@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
@@ -4950,6 +5871,12 @@ stream-splicer@^2.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
 
+stream-to-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
+  dependencies:
+    any-observable "^0.2.0"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -4974,6 +5901,14 @@ string_decoder@~1.0.0, string_decoder@~1.0.3:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.1.tgz#2720c2eff940854c819f6ee252aaeb581f30624d"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -5039,6 +5974,10 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -5102,6 +6041,10 @@ svgo@^1.0.0:
     unquote "^1.1.0"
     util.promisify "~1.0.0"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -5115,6 +6058,17 @@ syntax-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.3.0.tgz#1ed9266c4d40be75dc55bf9bb1cb77062bb96ca1"
   dependencies:
     acorn "^4.0.3"
+
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
 
 tar-pack@^3.4.0:
   version "3.4.1"
@@ -5180,9 +6134,13 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@^0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+the-argv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/the-argv/-/the-argv-1.0.0.tgz#0084705005730dd84db755253c931ae398db9522"
 
 through2-filter@^2.0.0:
   version "2.0.0"
@@ -5205,7 +6163,7 @@ through2@^2.0.0, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3":
+"through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5391,7 +6349,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typedarray@~0.0.5:
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
+
+typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
@@ -5448,6 +6412,10 @@ unique-temp-dir@^1.0.0:
     os-tmpdir "^1.0.1"
     uid2 "0.0.3"
 
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
+
 unquote@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.0.tgz#98e1fc608b6b854c75afb1b95afc099ba69d942f"
@@ -5460,7 +6428,7 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-update-notifier@^2.3.0:
+update-notifier@^2.1.0, update-notifier@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.3.0.tgz#4e8827a6bb915140ab093559d7014e3ebb837451"
   dependencies:
@@ -5496,6 +6464,12 @@ url@~0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  dependencies:
+    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -5617,7 +6591,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -5650,6 +6624,10 @@ wordwrap@0.0.2:
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -5684,7 +6662,7 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-json-file@^2.2.0:
+write-json-file@^2.0.0, write-json-file@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
   dependencies:
@@ -5695,12 +6673,25 @@ write-json-file@^2.2.0:
     sort-keys "^2.0.0"
     write-file-atomic "^2.0.0"
 
+write-pkg@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/write-pkg/-/write-pkg-2.1.0.tgz#353aa44c39c48c21440f5c08ce6abd46141c9c08"
+  dependencies:
+    sort-keys "^1.1.2"
+    write-json-file "^2.0.0"
+
 write-pkg@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/write-pkg/-/write-pkg-3.1.0.tgz#030a9994cc9993d25b4e75a9f1a1923607291ce9"
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"
@@ -5709,6 +6700,48 @@ xdg-basedir@^3.0.0:
 xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
+
+xo-init@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xo-init/-/xo-init-0.5.0.tgz#8e28dec79676cc5e042fde5fd8f710e2646b0e36"
+  dependencies:
+    arrify "^1.0.0"
+    execa "^0.5.0"
+    minimist "^1.1.3"
+    path-exists "^3.0.0"
+    read-pkg-up "^2.0.0"
+    the-argv "^1.0.0"
+    write-pkg "^2.0.0"
+
+xo@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/xo/-/xo-0.18.2.tgz#92a42eb02a4fb149dfea5518021914f5aac84ff0"
+  dependencies:
+    arrify "^1.0.0"
+    debug "^2.2.0"
+    deep-assign "^1.0.0"
+    eslint "^3.18.0"
+    eslint-config-xo "^0.18.0"
+    eslint-formatter-pretty "^1.0.0"
+    eslint-plugin-ava "^4.2.0"
+    eslint-plugin-import "^2.0.0"
+    eslint-plugin-no-use-extend-native "^0.3.2"
+    eslint-plugin-promise "^3.4.0"
+    eslint-plugin-unicorn "^2.1.0"
+    get-stdin "^5.0.0"
+    globby "^6.0.0"
+    has-flag "^2.0.0"
+    ignore "^3.2.6"
+    lodash.isequal "^4.4.0"
+    meow "^3.4.2"
+    multimatch "^2.1.0"
+    path-exists "^3.0.0"
+    pkg-conf "^2.0.0"
+    resolve-cwd "^1.0.0"
+    resolve-from "^2.0.0"
+    slash "^1.0.0"
+    update-notifier "^2.1.0"
+    xo-init "^0.5.0"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
We now are using xo instead of standard js since it is still almost
zero-config but allow for extra options. I was also quite sold on the
tabs vs spaces idea since those are dynamic representations of space and
can be tweaked to be displayed as any individual developer wants through
their text editor.

Additionally, we are also reformatting package.json and *.js files through
lint-staged on a precommit basis.